### PR TITLE
FHIR-51164: Updated name of profiles

### DIFF
--- a/input/fsh/profiles-eu/eu-allergyintolerance.fsh
+++ b/input/fsh/profiles-eu/eu-allergyintolerance.fsh
@@ -1,6 +1,6 @@
 Profile: AllergyIntoleranceEu
 Parent: AllergyIntolerance
-Title: "EU AllergyIntolerance"
+Title: "AllergyIntolerance: EU AllergyIntolerance"
 Description: "A allergyintolerance profile for the EU."
 * insert SetFmmAndStatusRule( 1, draft )
 * extension contains $allergyintolerance-abatement-url named abatement 0..1

--- a/input/fsh/profiles-eu/eu-bodystructure.fsh
+++ b/input/fsh/profiles-eu/eu-bodystructure.fsh
@@ -1,6 +1,6 @@
 Profile: BodyStructureEu
 Parent: BodyStructure
-Title: "EU BodyStructure"
+Title: "BodyStructure: EU BodyStructure"
 Description: "BodyStructure profile for the EU"
 * insert SetFmmAndStatusRule( 1, draft )
 * patient only Reference( $EuPatient )

--- a/input/fsh/profiles-eu/eu-careplan.fsh
+++ b/input/fsh/profiles-eu/eu-careplan.fsh
@@ -1,6 +1,6 @@
 Profile: CarePlanEu
 Parent: CarePlan
-Title: "EU CarePlan"
+Title: "CarePlan: EU CarePlan"
 Description: "Care plan for the patient. 
 Contains the narrative containing the plan including proposals, goals, and order requests for monitoring, tracking, or improving the condition of the patient. In the future it is expected that the care plan could be provided in a structured and coded format."
 * insert SetFmmAndStatusRule( 1, draft )

--- a/input/fsh/profiles-eu/eu-composition.fsh
+++ b/input/fsh/profiles-eu/eu-composition.fsh
@@ -1,6 +1,6 @@
 Profile: CompositionEu
 Parent: http://hl7.org/fhir/StructureDefinition/clinicaldocument
-Title: "EU Composition"
+Title: "Composition: EU Composition"
 Description: "Clinical document used to represent a report for the scope of the HL7 Europe project."
 * insert SetFmmAndStatusRule( 1, draft )
 

--- a/input/fsh/profiles-eu/eu-condition.fsh
+++ b/input/fsh/profiles-eu/eu-condition.fsh
@@ -1,6 +1,6 @@
 Profile: ConditionEu
 Parent: Condition
-Title: "EU Condition"
+Title: "Condition: EU Condition"
 Description: "A condition profile for the EU."
 * insert SetFmmAndStatusRule( 1, draft )
 * extension contains $artifact-related-artifact-url named relatedArtifact 0..*

--- a/input/fsh/profiles-eu/eu-documentreference.fsh
+++ b/input/fsh/profiles-eu/eu-documentreference.fsh
@@ -1,5 +1,6 @@
 Profile: DocumentReferenceEu
 Parent: DocumentReference
+Title: "DocumentReference: EU DocumentReference"
 Description: "A DocumentReference profile for the EU."
 * insert SetFmmAndStatusRule( 1, draft )
 // * extension contains $workflow-reason-url named reason 0..* // does not compile remove for now

--- a/input/fsh/profiles-eu/eu-encounter.fsh
+++ b/input/fsh/profiles-eu/eu-encounter.fsh
@@ -1,6 +1,6 @@
 Profile: EncounterEu
 Parent: Encounter
-Title: "EU Encounter"
+Title: "Encounter: EU Encounter"
 Description: "A encounter profile for the EU."
 * insert SetFmmAndStatusRule( 1, draft )
 * priority from http://terminology.hl7.org/ValueSet/v3-xEncounterAdmissionUrgency (preferred)

--- a/input/fsh/profiles-eu/eu-endpoint.fsh
+++ b/input/fsh/profiles-eu/eu-endpoint.fsh
@@ -1,6 +1,6 @@
 Profile: EndpointEu
 Parent: Endpoint
-Title: "EU Endpoint"
+Title: "Endpoint: EU Endpoint"
 Description: """
 The FHIR endpoint resource with EU specific references.
 """

--- a/input/fsh/profiles-eu/eu-medication.fsh
+++ b/input/fsh/profiles-eu/eu-medication.fsh
@@ -2,7 +2,7 @@
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 Profile:  MedicationEu
 Parent:   Medication
-Title:    "EU Medication"
+Title:    "Medication: EU Medication"
 Description: "A medication profile for the EU."
 //-------------------------------------------------------------------------------------------
 

--- a/input/fsh/profiles-eu/eu-observation.fsh
+++ b/input/fsh/profiles-eu/eu-observation.fsh
@@ -1,6 +1,6 @@
 Profile: ObservationEu
 Parent: Observation
-Title: "EU Observation"
+Title: "Observation: EU Observation"
 Description: "A observation profile for the EU."
 * insert SetFmmAndStatusRule( 1, draft )
 * effective[x] 1..1
@@ -24,7 +24,7 @@ Description: "A observation profile for the EU."
 Profile: QuantityEu
 Parent: Quantity
 Id: quantity-eu
-Title: "EU Quantity"
+Title: "Quantity: QuantityEu"
 Description: "A quantity profile for the EU."
 * insert SetFmmAndStatusRule( 1, draft )
 * extension contains $iso21090-uncertainty-url named uncertainty 0..1
@@ -32,7 +32,7 @@ Description: "A quantity profile for the EU."
 
 Profile: SimpleQuantityEu
 Parent: SimpleQuantity
-Title: "EU SimpleQuantity"
+Title: "SimpleQuantity: SimpleQuantityEu"
 Description: "A simple quantity profile for the EU."
 * insert SetFmmAndStatusRule( 1, draft )
 * extension contains $iso21090-uncertainty-url named uncertainty 0..1
@@ -41,7 +41,7 @@ Description: "A simple quantity profile for the EU."
 Profile: RangeEu
 Parent: Range
 Id: range-eu
-Title: "EU Range"
+Title: "Range: RangeEu"
 Description: "A range profile for the EU."
 * insert SetFmmAndStatusRule( 1, draft )
 * low only SimpleQuantityEu

--- a/input/fsh/profiles-eu/eu-patient-animal.fsh
+++ b/input/fsh/profiles-eu/eu-patient-animal.fsh
@@ -1,6 +1,6 @@
 Profile: PatientAnimalEu
 Parent: PatientEu
-Title: "Patient: Animal"
+Title: "Patient: EU Animal"
 Description: """This profile defines how to represent an Animal as subject of care in FHIR for the purpose of this guide. This is used (among others) to identify the species when a specimen is collected from an animal."""	
 * insert SetFmmAndStatusRule( 1, draft )
 * extension contains 

--- a/input/fsh/profiles-eu/eu-procedure.fsh
+++ b/input/fsh/profiles-eu/eu-procedure.fsh
@@ -1,6 +1,6 @@
 Profile: ProcedureEu
 Parent: Procedure
-Title: "EU Procedure"
+Title: "Procedure: EU Procedure"
 Description: "A procedure profile for the EU."
 * insert SetFmmAndStatusRule( 1, draft )
 

--- a/input/fsh/profiles-eu/eu-relatedperson.fsh
+++ b/input/fsh/profiles-eu/eu-relatedperson.fsh
@@ -1,6 +1,6 @@
 Profile: RelatedPersonEu
 Parent: RelatedPerson
-Title: "RelatedPerson Eu"
+Title: "RelatedPerson: EU RelatedPerson"
 Description: "EU Related Person."
 * insert SetFmmAndStatusRule( 1, draft )
 * name only $EuHumanName

--- a/input/fsh/profiles-eu/eu-specimen.fsh
+++ b/input/fsh/profiles-eu/eu-specimen.fsh
@@ -1,6 +1,6 @@
 Profile: SpecimenEu
 Parent: Specimen
-Title: "Specimen: Laboratory"
+Title: "Specimen: EU Specimen"
 Description: """This profile defines how to represent Specimens in HL7 FHIR for the purpose of this guide."""
 
 * insert SetFmmAndStatusRule( 1, draft )

--- a/input/fsh/profiles/im-adverseevent.fsh
+++ b/input/fsh/profiles/im-adverseevent.fsh
@@ -1,6 +1,6 @@
 Profile: ImAdverseEvent
 Parent: AdverseEvent
-Title: "Imaging Adverse Event"
+Title: "AdverseEvent: Imaging Adverse Event"
 Description: """Adverse Event that occurred during an imaging procedure."""
 * insert SetFmmAndStatusRule( 1, draft )
 

--- a/input/fsh/profiles/im-composition.fsh
+++ b/input/fsh/profiles/im-composition.fsh
@@ -1,6 +1,6 @@
 Profile: ImComposition
 Parent: CompositionEu
-Title: "Imaging Composition"
+Title: "Composition: Imaging Report"
 Description: "Clinical document used to represent a Imaging Study Report for the scope of the HL7 Europe project."
 * . ^short = "Imaging Report composition"
 * . ^definition = """

--- a/input/fsh/profiles/im-diagnosticreport.fsh
+++ b/input/fsh/profiles/im-diagnosticreport.fsh
@@ -1,6 +1,6 @@
 Profile: ImDiagnosticReport
 Parent: DiagnosticReport
-Title: "Imaging Diagnostic Report"
+Title: "DiagnosticReport: Imaging Report"
 Description: """
 Diagnostic Report profile for Imaging Reports. This document represents the report of an imaging study. It is the anchor resource that refers to all structured data as well as the `Composition` resource that contains the narrative text of the report.
 """

--- a/input/fsh/profiles/im-endpoint-ihe-iid-viewer.fsh
+++ b/input/fsh/profiles/im-endpoint-ihe-iid-viewer.fsh
@@ -1,6 +1,6 @@
 Profile: ImImageIidViewerEndpoint
 Parent: EndpointEu
-Title: "IM Image Viewer Endpoint"
+Title: "Endpoint: IHE IID Image Viewer"
 Description: """
 This profile defines a placeholder for an Endpoint for a viewer that can be used to access the study, serie it is present on.
 The application is based on [IHE-IID](https://www.ihe.net/uploadedFiles/Documents/Radiology/IHE_RAD_Suppl_IID.pdf).

--- a/input/fsh/profiles/im-endpoint-wado.fsh
+++ b/input/fsh/profiles/im-endpoint-wado.fsh
@@ -1,6 +1,6 @@
 Profile: ImWadoEndpoint
 Parent: EndpointEu
-Title: "IM WADO Endpoint"
+Title: "Endpoint: WADO-RS"
 Description: """
 This profile defines the WADO endpoint for accessing imaging study content.
 """

--- a/input/fsh/profiles/im-finding.fsh
+++ b/input/fsh/profiles/im-finding.fsh
@@ -1,6 +1,6 @@
 Profile: ImFinding
 Parent: $EuObservation
-Title: "Finding"
+Title: "Observation: Imaging Finding"
 Description: "Finding during imaging procedure."
 * insert SetFmmAndStatusRule( 1, draft )
 

--- a/input/fsh/profiles/im-gestational-age-observation.fsh
+++ b/input/fsh/profiles/im-gestational-age-observation.fsh
@@ -1,6 +1,6 @@
 Profile: ImGestationalAgeObservation
 Parent: $EuObservation
-Title: "Gestational Age Observation"
+Title: "Observation: Gestational Age"
 Description: "Gestational Age Observation"
 * insert SetFmmAndStatusRule( 1, draft )
 

--- a/input/fsh/profiles/im-identifiers.fsh
+++ b/input/fsh/profiles/im-identifiers.fsh
@@ -1,7 +1,7 @@
 Profile: ImAccessionNumberIdentifier
 Parent: Identifier
 Id: im-accession-number-identifier
-Title: "Imaging Accession Number Identifier"
+Title: "Identifier: Accession Number"
 Description: "This profile on Identifier represents the Accession Number for the Imaging Order."
 * insert SetFmmAndStatusRule( 1, draft )
 * system 1..1
@@ -17,7 +17,7 @@ RuleSet: BasedOnImOrderReference( slicename )
 Profile: ImStudyInstanceUidIdentifier
 Parent: Identifier
 Id: im-study-instance-uid-identifier
-Title: "Study Instance UID Identifier"
+Title: "Identifier: Study Instance UID"
 Description: "This profile on Identifier represents the Study Instance UID (0020,000D) for the Imaging Order."
 * insert SetFmmAndStatusRule( 1, draft )
 * system = "urn:dicom:uid"
@@ -28,7 +28,7 @@ Description: "This profile on Identifier represents the Study Instance UID (0020
 Profile: ImSopInstanceUidIdentifier
 Parent: Identifier
 Id: im-sop-instance-uid-identifier
-Title: "Imaging SOP Class UID Identifier"
+Title: "Identifier: SOP Instance UID"
 Description: "This profile on Identifier represents the SOP Class UID (0008,0018) for the Imaging Order."
 * insert SetFmmAndStatusRule( 1, draft )
 * system = "urn:dicom:uid"

--- a/input/fsh/profiles/im-ihemhd-documentreference.fsh
+++ b/input/fsh/profiles/im-ihemhd-documentreference.fsh
@@ -48,7 +48,7 @@ Description: """Report Obligations for ImReportIheMhdDocumentReference"""
 
 Profile: ImReportIheMhdDocumentReference
 Parent: ImIheMhdDocumentReference
-Title: "Report DocumentReference for MHD deployments"
+Title: "DocumentReference: IHE-MHD Imaging Report"
 Description: """
 A DocumentReference profile for the Report DocumentReference used in MHD deployments. """
 * insert SetFmmAndStatusRule( 1, draft )
@@ -127,7 +127,7 @@ Description: """Manifest Obligations for ImManifestIheMhdDocumentReference"""
 
 Profile: ImManifestIheMhdDocumentReference
 Parent: ImIheMhdDocumentReference
-Title: "Manifest DocumentReference for MHD deployments"
+Title: "DocumentReference: IHEMHD Imaging Manifest"
 Description: """
 A DocumentReference profile for the Manifest DocumentReference used in MHD deployments. """
 * insert SetFmmAndStatusRule( 1, draft )
@@ -162,7 +162,7 @@ A DocumentReference profile for the Manifest DocumentReference used in MHD deplo
 
 Profile: ImIheMhdDocumentReference
 Parent: DocumentReference
-Title: "R5 DocumentReference for MHD deployments"
+Title: "DocumentReference: IHE-MHD Document"
 Description: """A placeholder for a DocumentReference profile for the IHE-MHD in R5. """
 * insert SetFmmAndStatusRule( 1, draft )
 * modifierExtension 0..0
@@ -179,7 +179,7 @@ Description: """A placeholder for a DocumentReference profile for the IHE-MHD in
 
 Profile: IheMhdEntryUUIDIdentifier
 Parent: Identifier
-Title: "Placeholder for IHE MHD Entry UUID Identifier in FHIR R5."
+Title: "Identifier: IHE MHD Entry UUID"
 Description: """entryUUID Identifier holding a UUID, based on [IHE-MHD R4](https://profiles.ihe.net/ITI/MHD/StructureDefinition-IHE.MHD.EntryUUID.Identifier.html).
 """
 * insert SetFmmAndStatusRule( 1, draft )

--- a/input/fsh/profiles/im-imaging-device.fsh
+++ b/input/fsh/profiles/im-imaging-device.fsh
@@ -1,6 +1,6 @@
 Profile: ImImagingDevice
 Parent: Device
-Title: "Im Imaging Device"
+Title: "Device: Imaging Device"
 Description: """The device the made the image."""	
 * insert SetFmmAndStatusRule( 1, draft )
 * status 1..1

--- a/input/fsh/profiles/im-imagingselection.fsh
+++ b/input/fsh/profiles/im-imagingselection.fsh
@@ -1,6 +1,6 @@
 Profile: ImImagingSelection
 Parent: ImagingSelection
-Title: "Imaging Selection"
+Title: "ImagingSelection: General"
 Description: "Imaging Selection"
 * insert SetFmmAndStatusRule( 1, draft )
 * subject only Reference( $EuPatient )
@@ -13,7 +13,7 @@ Description: "Imaging Selection"
 
 Profile: ImSrInstanceImagingSelection
 Parent: ImImagingSelection
-Title: "Imaging Selection referring to a DICOM SR instance"
+Title: "ImagingSelection: DICOM SR Instance"
 Description: "Imaging Selection referring to a DICOM SR instance"
 * insert SetFmmAndStatusRule( 1, draft )
 * identifier 1..*

--- a/input/fsh/profiles/im-imagingstudy.fsh
+++ b/input/fsh/profiles/im-imagingstudy.fsh
@@ -1,6 +1,6 @@
 Profile: ImImagingStudy
 Parent: ImagingStudy
-Title: "IM Imaging Study"
+Title: "ImagingStudy: General"
 Description: """ 
 This profile represents an imaging study instance.
 """

--- a/input/fsh/profiles/im-keyimage-documentreference.fsh
+++ b/input/fsh/profiles/im-keyimage-documentreference.fsh
@@ -1,6 +1,6 @@
 Profile: ImKeyImageDocumentReference
 Parent: $EuDocumentReference
-Title: "Imaging Key Image Document Reference"
+Title: "DocumentReference: Key Image"
 Description: """A document containing key images for a patient. It can refer to a DICOM or non-DICOM image. When referring to a DICOM image, the DocumentReference.content.attachment.url should be a WADO-URI. When referring to a non-DICOM image, the DocumentReference.content.attachment.url should be a direct URL to the image.\n
 When the resource represents a DICOM instance it SHALL contain a the SOP Instance UID in the identifier element. When the resource represents a DICOM series it SHALL contain the Series Instance UID in the identifier element. 
 """

--- a/input/fsh/profiles/im-keyimage-imagingselection.fsh
+++ b/input/fsh/profiles/im-keyimage-imagingselection.fsh
@@ -1,6 +1,6 @@
 Profile: ImKeyImageImagingSelection
 Parent: ImImagingSelection
-Title: "Key images represented as an ImagingSelection"
+Title: "ImagingSelection: Key Image"
 Description: "Key images represented as an ImagingSelection"
 * insert SetFmmAndStatusRule( 1, draft )
 

--- a/input/fsh/profiles/im-manifest.fsh
+++ b/input/fsh/profiles/im-manifest.fsh
@@ -1,6 +1,6 @@
 Profile: ImImagingStudyManifest
 Parent: Bundle
-Title: "IM ImagingStudy Manifest"
+Title: "Bundle: ImagingStudy Manifest"
 Description: """
 This profile represents a manifest of an imaging study. It holds the ImagingStudy resource that mirrors the information in the DICOM study allow with other resources that are required to express the information in DICOM in FHIR.\n
 """

--- a/input/fsh/profiles/im-order.fsh
+++ b/input/fsh/profiles/im-order.fsh
@@ -1,6 +1,6 @@
 Profile: ImOrder
 Parent: $EuServiceRequest
-Title: "IM Imaging Order"
+Title: "ServiceRequest: Imaging Order"
 Description: "This profile on ServiceRequest represents the order for the Imaging Study and report."
 * insert SetFmmAndStatusRule( 1, draft )
 

--- a/input/fsh/profiles/im-patient.fsh
+++ b/input/fsh/profiles/im-patient.fsh
@@ -1,6 +1,6 @@
 Profile: ImPatient
 Parent: $EuPatient
-Title: "IM Imaging Patient"
+Title: "Patient: Imaging"
 Description: "This profile on Patient represents the Imaging Patient."
 * insert SetFmmAndStatusRule( 1, draft )
 * birthDate

--- a/input/fsh/profiles/im-procedure.fsh
+++ b/input/fsh/profiles/im-procedure.fsh
@@ -1,6 +1,6 @@
 Profile: ImProcedure
 Parent: $EuProcedure
-Title: "IM Imaging Procedure"
+Title: "Procedure: Imaging Acquisition"
 Description: "This profile on Procedure represents the imaging procedure."
 * insert SetFmmAndStatusRule( 1, draft )
 

--- a/input/fsh/profiles/im-radiationdose-observation.fsh
+++ b/input/fsh/profiles/im-radiationdose-observation.fsh
@@ -1,6 +1,6 @@
 Profile: ImRadiationDoseObservation
 Parent: $EuObservation
-Title: "Radiation Dose Observation"
+Title: "Observation: Radiation Dose"
 Description: """
 A record for the radiation dose the subject has been exposed to during an imaging procedure.
 E.g. based on information from https://dicom.nema.org/medical/dicom/current/output/html/part16.html and https://build.fhir.org/ig/HL7/fhir-radiation-dose-summary-ig/index.html

--- a/input/fsh/profiles/im-report.fsh
+++ b/input/fsh/profiles/im-report.fsh
@@ -1,6 +1,6 @@
 Profile: ImReport
 Parent: Bundle
-Title: "Document Bundle for Imaging Report"
+Title: "Bundle: Imaging Report"
 Description: "Document Bundle for Imaging Report"
 * insert SetFmmAndStatusRule( 1, draft )
 * type = #document


### PR DESCRIPTION
FHIR-51164: Updated name of profiles
- IM profiles following Resolution input
- EU profiles - discussed with Ignacio to update it to follow similar standard from IM. E.g., FHIR Resource Type: Name of Profile
- Obligations were not updated - Bas said to not do them for now.