### PR TITLE
FHIR-51127 Change of the name of profiles

### DIFF
--- a/input/fsh/alias-imProfiles.fsh
+++ b/input/fsh/alias-imProfiles.fsh
@@ -1,21 +1,22 @@
 // lists of EU profiles. Some of the EU profiles are defined in this IG as there has not yet been a
 // decision on where to host them. Using Aliases for them moves that choice to FHIR shorthand.
 
-Alias: $ImAdverseEvent                  = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImAdverseEvent
-Alias: $ImDiagnosticReportUrl           = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImDiagnosticReport
-Alias: $ImFindingUrl                    = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImFinding
-Alias: $ImGestationalAgeObservationUrl  = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImGestationalAgeObservation
-Alias: $ImImagingStudyUrl               = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImImagingStudy
-Alias: $ImCompositionUrl                = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImComposition
-Alias: $ImOrderUrl                      = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImOrder
-Alias: $ImPatientUrl                    = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImPatient
-Alias: $ImRadiationDoseObservationUrl   = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImRadiationDoseObservation
-Alias: $ImMedicationAdministrationUrl   = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImMedicationAdministration
-Alias: $ImServiceRequestUrl             = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImServiceRequest
-Alias: $ImAdverseEventUrl               = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImAdverseEvent
-Alias: $ImProcedureUrl                  = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImProcedure
-Alias: $ImWadoEndpointUrl               = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImWadoEndpoint
-Alias: $ImImageIidViewerEndpointUrl     = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImImageIidViewerEndpoint
-Alias: $ImKeyImageDocumentReferenceUrl  = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImKeyImageDocumentReference
-Alias: $ImReportUrl                     = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImReport
-Alias: $ImImagingStudyManifestUrl       = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImImagingStudyManifest
+
+Alias: $AdverseEventEuImaging                  = http://hl7.eu/fhir/imaging-r5/StructureDefinition/AdverseEventEuImaging
+Alias: $DiagnosticReportEuImagingUrl           = http://hl7.eu/fhir/imaging-r5/StructureDefinition/DiagnosticReportEuImaging
+Alias: $ObservationFindingEuImagingUrl                    = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ObservationFindingEuImaging
+Alias: $ObservationGestationalAgeEuImagingUrl  = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ObservationGestationalAgeEuImaging
+Alias: $ImagingStudyEuImagingUrl               = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ImagingStudyEuImaging
+Alias: $CompositionEuImagingUrl                = http://hl7.eu/fhir/imaging-r5/StructureDefinition/CompositionEuImaging
+Alias: $ServiceRequestOrderEuImagingUrl                      = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ServiceRequestOrderEuImaging
+Alias: $PatientEuImagingUrl                    = http://hl7.eu/fhir/imaging-r5/StructureDefinition/PatientEuImaging
+Alias: $ObservationRadiationDoseEuImagingUrl   = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ObservationRadiationDoseEuImaging
+Alias: $ImMedicationAdministrationUrl   = http://hl7.eu/fhir/imaging-r5/StructureDefinition/MedicationAdministrationEuImaging //CHECK - No profile found
+Alias: $ImServiceRequestUrl             = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ServiceRequestEuImaging //CHECK - No profile found
+Alias: $AdverseEventEuImagingUrl               = http://hl7.eu/fhir/imaging-r5/StructureDefinition/AdverseEventEuImaging
+Alias: $ProcedureEuImagingUrl                  = http://hl7.eu/fhir/imaging-r5/StructureDefinition/ProcedureEuImaging
+Alias: $EndpointWadoEuImagingUrl               = http://hl7.eu/fhir/imaging-r5/StructureDefinition/EndpointWadoEuImaging
+Alias: $EndpointImageIidViewerEuImagingUrl     = http://hl7.eu/fhir/imaging-r5/StructureDefinition/EndpointImageIidViewerEuImaging
+Alias: $DocumentReferenceKeyImageEuImagingUrl  = http://hl7.eu/fhir/imaging-r5/StructureDefinition/DocumentReferenceKeyImageEuImaging
+Alias: $BundleReportEuImagingUrl                     = http://hl7.eu/fhir/imaging-r5/StructureDefinition/BundleReportEuImaging
+Alias: $BundleImagingStudyManifestEuImagingUrl       = http://hl7.eu/fhir/imaging-r5/StructureDefinition/BundleImagingStudyManifestEuImaging

--- a/input/fsh/profiles/im-adverseevent.fsh
+++ b/input/fsh/profiles/im-adverseevent.fsh
@@ -1,15 +1,15 @@
-Profile: ImAdverseEvent
+Profile: AdverseEventEuImaging //ImAdverseEvent
 Parent: AdverseEvent
 Title: "AdverseEvent: Imaging Adverse Event"
 Description: """Adverse Event that occurred during an imaging procedure."""
 * insert SetFmmAndStatusRule( 1, draft )
 
-* subject only Reference(ImPatient or Group or $EuPractitioner or $EuRelatedPerson or ResearchSubject )
+* subject only Reference(PatientEuImaging or Group or $EuPractitioner or $EuRelatedPerson or ResearchSubject )
 
 * suspectEntity
   * insert SliceElement( #profile, instance )
 * suspectEntity contains procedure 0..*
-* suspectEntity[procedure].instanceReference only Reference(ImProcedure)
+* suspectEntity[procedure].instanceReference only Reference(ProcedureEuImaging)
 
 * contributingFactor
   * insert SliceElement( #profile, $this )

--- a/input/fsh/profiles/im-composition.fsh
+++ b/input/fsh/profiles/im-composition.fsh
@@ -1,4 +1,4 @@
-Profile: ImComposition
+Profile: CompositionEuImaging
 Parent: CompositionEu
 Title: "Composition: Imaging Report"
 Description: "Clinical document used to represent a Imaging Study Report for the scope of the HL7 Europe project."
@@ -18,7 +18,7 @@ The `text` field of each section SHALL contain a textual representation of all l
 * identifier 1..*
 * extension contains 
     ImDiagnosticReportReference named diagnosticreport-reference 1..1  
-* extension[diagnosticreport-reference].valueReference only Reference ( ImDiagnosticReport )
+* extension[diagnosticreport-reference].valueReference only Reference ( DiagnosticReportEuImaging )
 
 * custodian only Reference( $EuOrganization )
   * ^short = "Organization that manages the Imaging Report"
@@ -72,13 +72,13 @@ The `text` field of each section SHALL contain a textual representation of all l
   * ^definition = "The type of imaging modality used to perform the study."
   * detail 1..*
   * detail from https://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html (extensible)
-  * detail only CodeableReference ( ImImagingStudy )
+  * detail only CodeableReference ( ImagingStudyEuImaging )
 * event[procedure]
   * ^short = "Study Type"
   * ^definition = "The type of imaging study performed."
   * detail 1..*
   * detail from https://www.hl7.org/fhir/valueset-procedure-reason.html (extensible)
-  * detail only CodeableReference ( ImProcedure )
+  * detail only CodeableReference ( ProcedureEuImaging )
 
 * section.code 1..1 
 * section 
@@ -109,7 +109,7 @@ The `text` field of each section SHALL contain a textual representation of all l
   * entry[imagingstudy]
     * ^short = "Imaging Study Reference"
     * ^definition = "This entry holds a reference to the Imaging Study instance that is associated with this Composition."
-  * entry[imagingstudy] only Reference(ImImagingStudy)  
+  * entry[imagingstudy] only Reference(ImagingStudyEuImaging)  
 
 // ///////////////////////////////// ORDER SECTION ///////////////////////////////////////
 * section[order]
@@ -126,7 +126,7 @@ The `text` field of each section SHALL contain a textual representation of all l
   * entry[order]
     * ^short = "Order reference"
     * ^definition = "This entry holds a reference to the order for the Imaging Study and report."
-  * entry[order] only Reference(ImOrder)  
+  * entry[order] only Reference(ServiceRequestOrderEuImaging)  
   
 
 // // ///////////////////////////////// HISTORY SECTION ///////////////////////////////////////
@@ -144,7 +144,7 @@ The `text` field of each section SHALL contain a textual representation of all l
     * insert SliceElement( #profile, $this )
   * entry contains 
       procedure 0..*
-  * entry[procedure] only Reference(ImProcedure)
+  * entry[procedure] only Reference(ProcedureEuImaging)
 
 
 // ////////////////// COMPARISON SECTION //////////////////////////
@@ -156,7 +156,7 @@ The `text` field of each section SHALL contain a textual representation of all l
     * insert SliceElement( #profile, $this )
   * entry contains 
       comparedstudy 0..*
-  * entry[comparedstudy] only Reference( ImImagingStudy or ImImagingSelection )
+  * entry[comparedstudy] only Reference( ImagingStudyEuImaging or ImagingSelectionEuImaging )
 
 // /////////////////// FINDINGS SECTION //////////////////////////
 * section[findings]
@@ -168,8 +168,8 @@ The `text` field of each section SHALL contain a textual representation of all l
   * entry contains 
       finding 0..* and
       keyimage 0..*
-  * entry[finding] only Reference(ImFinding)
-  * entry[keyimage] only Reference(ImKeyImageDocumentReference or ImKeyImageImagingSelection)
+  * entry[finding] only Reference(ObservationFindingEuImaging)
+  * entry[keyimage] only Reference(DocumentReferenceKeyImageEuImaging or ImagingSelectionKeyImageEuImaging)
 
 // /////////////////// IMPRESSION SECTION //////////////////////////
 * section[impression]
@@ -182,9 +182,9 @@ The `text` field of each section SHALL contain a textual representation of all l
       finding 0..* and
       impression 0..* and
       keyimage 0..*
-  * entry[finding] only Reference(ImFinding)
+  * entry[finding] only Reference(ObservationFindingEuImaging)
   * entry[impression] only Reference( $EuCondition )
-  * entry[keyimage] only Reference(ImKeyImageDocumentReference or ImKeyImageImagingSelection)
+  * entry[keyimage] only Reference(DocumentReferenceKeyImageEuImaging or ImagingSelectionKeyImageEuImaging)
 
 // /////////////////// RECOMMENDATION SECTION //////////////////////////
 * section[recommendation]
@@ -220,4 +220,4 @@ Context: Composition
 // publisher, contact, and other metadata here using caret (^) syntax (omitted)
 * insert ExtensionContext(Composition)
 * insert SetFmmAndStatusRule ( 2, draft )
-* value[x] only Reference (ImDiagnosticReport)
+* value[x] only Reference (DiagnosticReportEuImaging)

--- a/input/fsh/profiles/im-diagnosticreport.fsh
+++ b/input/fsh/profiles/im-diagnosticreport.fsh
@@ -1,4 +1,4 @@
-Profile: ImDiagnosticReport
+Profile: DiagnosticReportEuImaging //ImDiagnosticReport
 Parent: DiagnosticReport
 Title: "DiagnosticReport: Imaging Report"
 Description: """
@@ -32,9 +32,9 @@ Diagnostic Report profile for Imaging Reports. This document represents the repo
 * category[imaging] = $loinc#18748-4 "Diagnostic imaging study"
 * category[imaging].coding 1..1
 
-* subject only Reference(ImPatient)
+* subject only Reference(PatientEuImaging)
 
-* study only Reference(ImImagingStudy)
+* study only Reference(ImagingStudyEuImaging)
 
 // supporting info
 * supportingInfo
@@ -44,7 +44,7 @@ Diagnostic Report profile for Imaging Reports. This document represents the repo
     procedure 0..*
 * supportingInfo[procedure]
   * type = DiagnosticReportSupportingInfoCodeSystem#imaging-procedure
-  * reference only Reference(ImProcedure)
+  * reference only Reference(ProcedureEuImaging)
 // TODO only main elements or all elements of the eHN dataset?   
 
 * performer 
@@ -62,7 +62,7 @@ Diagnostic Report profile for Imaging Reports. This document represents the repo
 // refer to the mandatory composition
 * composition 1..1
 * composition ^short = "Imaging Diagnostic Report"
-* composition only Reference(ImComposition)
+* composition only Reference(CompositionEuImaging)
 
 // code 
 * code

--- a/input/fsh/profiles/im-endpoint-ihe-iid-viewer.fsh
+++ b/input/fsh/profiles/im-endpoint-ihe-iid-viewer.fsh
@@ -1,4 +1,4 @@
-Profile: ImImageIidViewerEndpoint
+Profile: EndpointImageIidViewerEuImaging //ImImageIidViewerEndpoint
 Parent: EndpointEu
 Title: "Endpoint: IHE IID Image Viewer"
 Description: """

--- a/input/fsh/profiles/im-endpoint-wado.fsh
+++ b/input/fsh/profiles/im-endpoint-wado.fsh
@@ -1,4 +1,4 @@
-Profile: ImWadoEndpoint
+Profile: EndpointWadoEuImaging //ImWadoEndpoint
 Parent: EndpointEu
 Title: "Endpoint: WADO-RS"
 Description: """

--- a/input/fsh/profiles/im-finding.fsh
+++ b/input/fsh/profiles/im-finding.fsh
@@ -1,4 +1,4 @@
-Profile: ImFinding
+Profile: ObservationFindingEuImaging //ImFinding
 Parent: $EuObservation
 Title: "Observation: Imaging Finding"
 Description: "Finding during imaging procedure."

--- a/input/fsh/profiles/im-gestational-age-observation.fsh
+++ b/input/fsh/profiles/im-gestational-age-observation.fsh
@@ -1,4 +1,4 @@
-Profile: ImGestationalAgeObservation
+Profile: ObservationGestationalAgeEuImaging //ImGestationalAgeObservation
 Parent: $EuObservation
 Title: "Observation: Gestational Age"
 Description: "Gestational Age Observation"

--- a/input/fsh/profiles/im-identifiers.fsh
+++ b/input/fsh/profiles/im-identifiers.fsh
@@ -1,4 +1,4 @@
-Profile: ImAccessionNumberIdentifier
+Profile: IdentifierAccessionNumberEuImaging
 Parent: Identifier
 Id: im-accession-number-identifier
 Title: "Identifier: Accession Number"
@@ -10,11 +10,11 @@ Description: "This profile on Identifier represents the Accession Number for the
 * type = http://terminology.hl7.org/CodeSystem/v2-0203#ACSN
 
 RuleSet: BasedOnImOrderReference( slicename )
-* basedOn[{slicename}] only Reference( ImOrder )
+* basedOn[{slicename}] only Reference( ServiceRequestOrderEuImaging )
   * identifier 1..1
-  * identifier only ImAccessionNumberIdentifier
+  * identifier only IdentifierAccessionNumberEuImaging
 
-Profile: ImStudyInstanceUidIdentifier
+Profile: IdentifierStudyInstanceUidEuImaging
 Parent: Identifier
 Id: im-study-instance-uid-identifier
 Title: "Identifier: Study Instance UID"
@@ -25,7 +25,7 @@ Description: "This profile on Identifier represents the Study Instance UID (0020
 * type 0..1
 * type = MissingDicomTerminology#0020000D "Study Instance UID" 
 
-Profile: ImSopInstanceUidIdentifier
+Profile: IdentifierSopInstanceUidEuImaging
 Parent: Identifier
 Id: im-sop-instance-uid-identifier
 Title: "Identifier: SOP Instance UID"

--- a/input/fsh/profiles/im-ihemhd-documentreference.fsh
+++ b/input/fsh/profiles/im-ihemhd-documentreference.fsh
@@ -1,6 +1,6 @@
-Profile: Report_ImReportDocumentReference
+Profile: DocumentReferenceReportEuImaging
 Id: Report-ImReportDocumentReference
-Parent: ImReportIheMhdDocumentReference
+Parent: DocumentReferenceReportIheMhdEuImaging
 Title: "Report Obligations for ImReportIheMhdDocumentReference"
 Description: """Report Obligations for ImReportIheMhdDocumentReference"""
 * insert SetFmmAndStatusRule( 1, draft )
@@ -46,8 +46,8 @@ Description: """Report Obligations for ImReportIheMhdDocumentReference"""
   * ^extension[http://hl7.org/fhir/StructureDefinition/obligation][+].extension[code].valueCode = #SHALL:populate
   * ^extension[http://hl7.org/fhir/StructureDefinition/obligation][=].extension[actor].valueCanonical = Canonical(ImReportProvider)
 
-Profile: ImReportIheMhdDocumentReference
-Parent: ImIheMhdDocumentReference
+Profile: DocumentReferenceReportIheMhdEuImaging
+Parent: DocumentReferenceIheMhdEuImaging
 Title: "DocumentReference: IHE-MHD Imaging Report"
 Description: """
 A DocumentReference profile for the Report DocumentReference used in MHD deployments. """
@@ -76,15 +76,15 @@ A DocumentReference profile for the Report DocumentReference used in MHD deploym
   * profile 1..*
     * insert SliceElement( #value, value )
   * profile contains hl7eu-imaging-report 1..1 
-  * profile[hl7eu-imaging-report].valueCanonical = Canonical( ImReport )
+  * profile[hl7eu-imaging-report].valueCanonical = Canonical( BundleReportEuImaging )
 * bodySite 0..*
 * modality 1..* 
 
-Profile: Manifest_ImManifestDocumentReference
+Profile: DocumentReferenceManifestEuImaging
 Id: Manifest-ImManifestDocumentReference
-Parent: ImManifestIheMhdDocumentReference
-Title: "Manifest Obligations for ImManifestIheMhdDocumentReference"
-Description: """Manifest Obligations for ImManifestIheMhdDocumentReference"""
+Parent: DocumentReferenceManifestIheMhdEuImaging
+Title: "Manifest Obligations for DocumentReferenceManifestIheMhdEuImaging"
+Description: """Manifest Obligations for DocumentReferenceManifestIheMhdEuImaging"""
 * insert SetFmmAndStatusRule( 1, draft )
 * identifier[entry-uuid]
   * ^extension[http://hl7.org/fhir/StructureDefinition/obligation][+].extension[code].valueCode = #SHALL:populate-if-known
@@ -125,8 +125,8 @@ Description: """Manifest Obligations for ImManifestIheMhdDocumentReference"""
   * ^extension[http://hl7.org/fhir/StructureDefinition/obligation][+].extension[code].valueCode = #SHALL:populate
   * ^extension[http://hl7.org/fhir/StructureDefinition/obligation][=].extension[actor].valueCanonical = Canonical(ImManifestProvider)
 
-Profile: ImManifestIheMhdDocumentReference
-Parent: ImIheMhdDocumentReference
+Profile: DocumentReferenceManifestIheMhdEuImaging
+Parent: DocumentReferenceIheMhdEuImaging
 Title: "DocumentReference: IHEMHD Imaging Manifest"
 Description: """
 A DocumentReference profile for the Manifest DocumentReference used in MHD deployments. """
@@ -156,11 +156,11 @@ A DocumentReference profile for the Manifest DocumentReference used in MHD deplo
   * profile 1..*
     * insert SliceElement( #value, value )
   * profile contains hl7eu-imaging-manifest 1..1 
-  * profile[hl7eu-imaging-manifest].valueCanonical = Canonical( ImImagingStudyManifest )
+  * profile[hl7eu-imaging-manifest].valueCanonical = Canonical( BundleImagingStudyManifestEuImaging )
 * bodySite 0..*
 * modality 1..* 
 
-Profile: ImIheMhdDocumentReference
+Profile: DocumentReferenceIheMhdEuImaging
 Parent: DocumentReference
 Title: "DocumentReference: IHE-MHD Document"
 Description: """A placeholder for a DocumentReference profile for the IHE-MHD in R5. """
@@ -169,7 +169,7 @@ Description: """A placeholder for a DocumentReference profile for the IHE-MHD in
 * identifier
   * insert SliceElement( #value, system )
 * identifier contains entry-uuid 1..1
-* identifier[entry-uuid] only IheMhdEntryUUIDIdentifier
+* identifier[entry-uuid] only IdentifierIheMhdEntryUUIDEuImaging
 * status 1..1 
 * content 1..1
   * attachment 1..1
@@ -177,7 +177,7 @@ Description: """A placeholder for a DocumentReference profile for the IHE-MHD in
 
 
 
-Profile: IheMhdEntryUUIDIdentifier
+Profile: IdentifierIheMhdEntryUUIDEuImaging
 Parent: Identifier
 Title: "Identifier: IHE MHD Entry UUID"
 Description: """entryUUID Identifier holding a UUID, based on [IHE-MHD R4](https://profiles.ihe.net/ITI/MHD/StructureDefinition-IHE.MHD.EntryUUID.Identifier.html).

--- a/input/fsh/profiles/im-imaging-device.fsh
+++ b/input/fsh/profiles/im-imaging-device.fsh
@@ -1,4 +1,4 @@
-Profile: ImImagingDevice
+Profile: DeviceImagingEuImaging //ImImagingDevice
 Parent: Device
 Title: "Device: Imaging Device"
 Description: """The device the made the image."""	
@@ -9,10 +9,10 @@ Description: """The device the made the image."""
 * category contains imaging 1..1
 * category[imaging] = $sct#314789007 "Diagnostic imaging equipment"
 
-* type from ImImagingDeviceType (extensible)
+* type from ValueSetImagingDeviceTypeEuImaging (extensible)
 
 
-ValueSet: ImImagingDeviceType
+ValueSet: ValueSetImagingDeviceTypeEuImaging
 Id: im-imaging-device-type
 Title: "Imaging Device Type"
 Description: "Imaging Device Type."
@@ -20,8 +20,8 @@ Description: "Imaging Device Type."
 * ^experimental = false
 * include codes from system $sct where concept is-a #314789007 "Diagnostic imaging equipment"
 
-Mapping: DicomToImImagingDevice
-Source: ImImagingDevice
+Mapping: DicomToImImagingDevice //check name - should it be updated? FHIR-51127
+Source: DeviceImagingEuImaging
 Target: "http://nema.org/dicom"
 Id: dicom-2-im-imaging-device-mapping
 Title: "Mapping from DICOM to Imaging Device"

--- a/input/fsh/profiles/im-imagingselection.fsh
+++ b/input/fsh/profiles/im-imagingselection.fsh
@@ -1,4 +1,4 @@
-Profile: ImImagingSelection
+Profile: ImagingSelectionEuImaging //ImImagingSelection
 Parent: ImagingSelection
 Title: "ImagingSelection: General"
 Description: "Imaging Selection"
@@ -8,18 +8,18 @@ Description: "Imaging Selection"
 * derivedFrom 1..*
   * insert SliceElement( #profile, $this )
 * derivedFrom contains study 1..1
-* derivedFrom[study] only Reference( ImImagingStudy )
+* derivedFrom[study] only Reference( ImagingStudyEuImaging )
 
 
-Profile: ImSrInstanceImagingSelection
-Parent: ImImagingSelection
+Profile: ImagingSelectionSrInstanceEuImaging
+Parent: ImagingSelectionEuImaging
 Title: "ImagingSelection: DICOM SR Instance"
 Description: "Imaging Selection referring to a DICOM SR instance"
 * insert SetFmmAndStatusRule( 1, draft )
 * identifier 1..*
   * insert SliceElement( #value, type )
 * identifier contains sopInstanceUid 1..1
-* identifier[sopInstanceUid] only ImSopInstanceUidIdentifier
+* identifier[sopInstanceUid] only IdentifierSopInstanceUidEuImaging
 
 * studyUid 1..1
 * seriesUid 1..1

--- a/input/fsh/profiles/im-imagingstudy.fsh
+++ b/input/fsh/profiles/im-imagingstudy.fsh
@@ -1,4 +1,4 @@
-Profile: ImImagingStudy
+Profile: ImagingStudyEuImaging
 Parent: ImagingStudy
 Title: "ImagingStudy: General"
 Description: """ 
@@ -10,7 +10,7 @@ This profile represents an imaging study instance.
 * identifier
   * insert SliceElement( #value, system )
 * identifier contains studyInstanceUid 1..1
-* identifier[studyInstanceUid] only ImStudyInstanceUidIdentifier
+* identifier[studyInstanceUid] only IdentifierStudyInstanceUidEuImaging
 
 * subject 1..1
 * subject only Reference( $EuPatient or $EuDevice )
@@ -36,7 +36,7 @@ This profile represents an imaging study instance.
     * actor only Reference( $EuOrganization )
   * performer[device]
     * function = http://terminology.hl7.org/CodeSystem/v3-ParticipationType#DEV
-    * actor only Reference( ImImagingDevice ) 
+    * actor only Reference( DeviceImagingEuImaging ) 
 
   * insert EndpointTypes 
 
@@ -61,5 +61,5 @@ RuleSet: EndpointTypes
 * endpoint 0..*  
   * insert SliceElement( #profile, $this )
 * endpoint contains wado 0..1 and iid 0..1
-* endpoint[wado] only Reference( ImWadoEndpoint )
-* endpoint[iid] only Reference( ImImageIidViewerEndpoint )
+* endpoint[wado] only Reference( EndpointWadoEuImaging )
+* endpoint[iid] only Reference( EndpointImageIidViewerEuImaging )

--- a/input/fsh/profiles/im-keyimage-documentreference.fsh
+++ b/input/fsh/profiles/im-keyimage-documentreference.fsh
@@ -1,4 +1,4 @@
-Profile: ImKeyImageDocumentReference
+Profile: DocumentReferenceKeyImageEuImaging
 Parent: $EuDocumentReference
 Title: "DocumentReference: Key Image"
 Description: """A document containing key images for a patient. It can refer to a DICOM or non-DICOM image. When referring to a DICOM image, the DocumentReference.content.attachment.url should be a WADO-URI. When referring to a non-DICOM image, the DocumentReference.content.attachment.url should be a direct URL to the image.\n
@@ -39,7 +39,7 @@ When the resource represents a DICOM instance it SHALL contain a the SOP Instanc
 * modality 1..1
   
 * subject 1..1
-* subject only Reference( ImPatient )
+* subject only Reference( PatientEuImaging )
 
 * author
   * insert SliceElement( #profile, $this )

--- a/input/fsh/profiles/im-keyimage-imagingselection.fsh
+++ b/input/fsh/profiles/im-keyimage-imagingselection.fsh
@@ -1,5 +1,5 @@
-Profile: ImKeyImageImagingSelection
-Parent: ImImagingSelection
+Profile: ImagingSelectionKeyImageEuImaging
+Parent: ImagingSelectionEuImaging
 Title: "ImagingSelection: Key Image"
 Description: "Key images represented as an ImagingSelection"
 * insert SetFmmAndStatusRule( 1, draft )
@@ -14,4 +14,4 @@ Description: "Key images represented as an ImagingSelection"
 * performer[performer]
   * actor only Reference( $EuPractitionerRole )
 * performer[device]
-  * actor only Reference( ImImagingDevice )
+  * actor only Reference( DeviceImagingEuImaging )

--- a/input/fsh/profiles/im-manifest.fsh
+++ b/input/fsh/profiles/im-manifest.fsh
@@ -1,4 +1,4 @@
-Profile: ImImagingStudyManifest
+Profile: BundleImagingStudyManifestEuImaging
 Parent: Bundle
 Title: "Bundle: ImagingStudy Manifest"
 Description: """
@@ -17,7 +17,7 @@ This profile represents a manifest of an imaging study. It holds the ImagingStud
 * entry[imagingstudy]
   * fullUrl 1..1
   * resource 1..1
-  * resource only ImImagingStudy
+  * resource only ImagingStudyEuImaging
 * entry[patient]
   * fullUrl 1..1
   * resource 1..1
@@ -25,15 +25,15 @@ This profile represents a manifest of an imaging study. It holds the ImagingStud
 * entry[order]
   * fullUrl 1..1
   * resource 1..1
-  * resource only ImOrder
+  * resource only ServiceRequestOrderEuImaging
 * entry[endpoint]
   * fullUrl 1..1
   * resource 1..1
-  * resource only ImWadoEndpoint or ImImageIidViewerEndpoint
+  * resource only EndpointWadoEuImaging or EndpointImageIidViewerEuImaging
 * entry[imagingdevice]
   * fullUrl 1..1
   * resource 1..1
-  * resource only ImImagingDevice
+  * resource only DeviceImagingEuImaging  
 * entry[practitioner]
   * fullUrl 1..1
   * resource 1..1

--- a/input/fsh/profiles/im-order.fsh
+++ b/input/fsh/profiles/im-order.fsh
@@ -1,4 +1,4 @@
-Profile: ImOrder
+Profile: ServiceRequestOrderEuImaging
 Parent: $EuServiceRequest
 Title: "ServiceRequest: Imaging Order"
 Description: "This profile on ServiceRequest represents the order for the Imaging Study and report."
@@ -12,7 +12,7 @@ Description: "This profile on ServiceRequest represents the order for the Imagin
 * identifier
   * insert SliceElement( #value, type )
 * identifier contains accessionNumber 0..1
-* identifier[accessionNumber] only ImAccessionNumberIdentifier
+* identifier[accessionNumber] only IdentifierAccessionNumberEuImaging
 
 * supportingInfo 0..*
   * insert SliceElement( #value, $this )
@@ -46,8 +46,8 @@ Description: "This profile on ServiceRequest represents the order for the Imagin
 
 
 
-Mapping: DicomToImOrder
-Source: ImOrder
+Mapping: DicomToImOrder //CHECK, do we need to change the name?
+Source: ServiceRequestOrderEuImaging
 Target: "http://nema.org/dicom"
 Id: dicom-2-im-order-mapping
 Title: "Mapping from DICOM to Imaging Order"

--- a/input/fsh/profiles/im-patient.fsh
+++ b/input/fsh/profiles/im-patient.fsh
@@ -1,4 +1,4 @@
-Profile: ImPatient
+Profile: PatientEuImaging
 Parent: $EuPatient
 Title: "Patient: Imaging"
 Description: "This profile on Patient represents the Imaging Patient."

--- a/input/fsh/profiles/im-procedure.fsh
+++ b/input/fsh/profiles/im-procedure.fsh
@@ -1,4 +1,4 @@
-Profile: ImProcedure
+Profile: ProcedureEuImaging
 Parent: $EuProcedure
 Title: "Procedure: Imaging Acquisition"
 Description: "This profile on Procedure represents the imaging procedure."
@@ -30,4 +30,4 @@ Description: "This profile on Procedure represents the imaging procedure."
       * insert SliceElement( #value, "$this" )
     * coding contains imaging-equipment 0..1
     * coding[imaging-equipment] = $sct#314789007 "Diagnostic imaging equipment" // TODO check this code
-  * actor only Reference(ImImagingDevice)
+  * actor only Reference(DeviceImagingEuImaging)

--- a/input/fsh/profiles/im-radiationdose-observation.fsh
+++ b/input/fsh/profiles/im-radiationdose-observation.fsh
@@ -1,4 +1,4 @@
-Profile: ImRadiationDoseObservation
+Profile: ObservationRadiationDoseEuImaging
 Parent: $EuObservation
 Title: "Observation: Radiation Dose"
 Description: """
@@ -21,12 +21,12 @@ E.g. based on information from https://dicom.nema.org/medical/dicom/current/outp
 * partOf 1..*
   * insert SliceElement( #profile, $this )
 * partOf contains study 1..1
-* partOf[study] only Reference( ImImagingStudy )
+* partOf[study] only Reference( ImagingStudyEuImaging )
 
 * derivedFrom 1..*
   * insert SliceElement( #profile, $this )
 * derivedFrom contains dicomInstance 1..1
-* derivedFrom[dicomInstance] only Reference( ImSrInstanceImagingSelection )
+* derivedFrom[dicomInstance] only Reference( ImagingSelectionSrInstanceEuImaging )
 
 * code
   * coding 1..*
@@ -45,7 +45,7 @@ E.g. based on information from https://dicom.nema.org/medical/dicom/current/outp
 
 // Performing irradiation device
 * device 
-* device only Reference(ImImagingDevice)
+* device only Reference(DeviceImagingEuImaging)
 * device ^short = "Irradiating modality"
 
 // dose measurements
@@ -59,55 +59,55 @@ E.g. based on information from https://dicom.nema.org/medical/dicom/current/outp
 * component[doseAreaProductTotal]
   * code = $dcm#113722 "Dose Area Product Total"
   * value[x] only QuantityEu
-  * valueQuantity from ImGraySquareUnits
+  * valueQuantity from ValueSetGraySquareUnitsEuImaging
 * component[fluorDoseAreaProductTotal]
   * code = $dcm#113726 "Fluoro Dose Area Product Total"
   * value[x] only QuantityEu
-  * valueQuantity from ImGraySquareUnits
+  * valueQuantity from ValueSetGraySquareUnitsEuImaging
 * component[doseAreaProduct]
   * code = $dcm#122130 "Dose Area Product"
   * value[x] only QuantityEu
-  * valueQuantity from ImGraySquareUnits
+  * valueQuantity from ValueSetGraySquareUnitsEuImaging
 
 * component[CTDoseLengthProductTotal]
   * code = $dcm#113813 "CT Dose Length Product Total"
   * value[x] only QuantityEu
-  * valueQuantity from ImDoseLengthUnits
+  * valueQuantity from ValueSetDoseLengthUnitsEuImaging
 * component[DLP]
   * code = $dcm#113838 "DLP"
   * value[x] only QuantityEu
-  * valueQuantity from ImDoseLengthUnits
+  * valueQuantity from ValueSetDoseLengthUnitsEuImaging
 * component[DLPAlertValue]
   * code = $dcm#113903 "DLP Alert Value"
   * value[x] only QuantityEu
-  * valueQuantity from ImDoseLengthUnits
+  * valueQuantity from ValueSetDoseLengthUnitsEuImaging
 * component[AccumulatedDLPForwardEstimate]  
   * code = $dcm#113905 "Accumulated DLP Forward Estimate"
   * value[x] only QuantityEu
-  * valueQuantity from ImDoseLengthUnits
+  * valueQuantity from ValueSetDoseLengthUnitsEuImaging
 * component[DLPNotificationValue]
   * code = $dcm#113911 "DLP Notification Value"
   * value[x] only QuantityEu
-  * valueQuantity from ImDoseLengthUnits
+  * valueQuantity from ValueSetDoseLengthUnitsEuImaging
 * component[DLPForwardEstimate]
   * code = $dcm#113913 "DLP Forward Estimate"
   * value[x] only QuantityEu
-  * valueQuantity from ImDoseLengthUnits
+  * valueQuantity from ValueSetDoseLengthUnitsEuImaging
 * component[CRDoseLengthProductSubTotal]
   * code = $dcm#130745 "CT Dose Length Product Sub-Total"
   * value[x] only QuantityEu
-  * valueQuantity from ImDoseLengthUnits
+  * valueQuantity from ValueSetDoseLengthUnitsEuImaging
 
 * component[CTEffectiveDoseTotal]
   * code = $dcm#113814 "CT Effective Dose Total"
   * value[x] only QuantityEu
-  * valueQuantity from ImEffectiveDoseUnits
+  * valueQuantity from ValueSetEffectiveDoseUnitsEuImaging
 * component[EffectiveDose]
   * code = $dcm#113839 "Effective Dose"
   * value[x] only QuantityEu
-  * valueQuantity from ImEffectiveDoseUnits
+  * valueQuantity from ValueSetEffectiveDoseUnitsEuImaging
 
-ValueSet: ImEffectiveDoseUnits
+ValueSet: ValueSetEffectiveDoseUnitsEuImaging
 Id: im-effective-dose-units
 Title: "Effective Dose Units"
 Description: "Units for Effective Dose."
@@ -116,14 +116,14 @@ Description: "Units for Effective Dose."
 * $ucum#Sv "Sv"        // Effective Dose
 * $ucum#mSv "mSv"       // Effective Dose
 
-ValueSet: ImDoseLengthUnits
+ValueSet: ValueSetDoseLengthUnitsEuImaging
 Id: im-dose-length-units
 Title: "Dose Length Units"
 Description: "Units for Dose Length."
 * ^experimental = false
 * $ucum#mGy.cm "mGy.cm" // Dose length product
 
-ValueSet: ImGraySquareUnits
+ValueSet: ValueSetGraySquareUnitsEuImaging
 Id: im-gray-square-units
 Title: "Gray Square Units"
 Description: "Units for Gray Square."

--- a/input/fsh/profiles/im-report.fsh
+++ b/input/fsh/profiles/im-report.fsh
@@ -1,4 +1,4 @@
-Profile: ImReport
+Profile: BundleReportEuImaging
 Parent: Bundle
 Title: "Bundle: Imaging Report"
 Description: "Document Bundle for Imaging Report"
@@ -10,6 +10,6 @@ Description: "Document Bundle for Imaging Report"
     imComposition 1..1 and
     imDiagnosticReport 1..1
 * entry[imComposition]
-  * resource only ImComposition
+  * resource only CompositionEuImaging
 * entry[imDiagnosticReport]
-  * resource only ImDiagnosticReport
+  * resource only DiagnosticReportEuImaging

--- a/scripts/generateDataBasedOnModel.js
+++ b/scripts/generateDataBasedOnModel.js
@@ -434,7 +434,7 @@ function writeActorObligationFiles( parsedData, obligationResources, actor, acto
             writable.write(`////////////////////////////////////////////////////\n`);
   
             writable.write(`Profile: ${actor}_${resourceName}\n`);
-            writable.write(`Parent: ${resourceUrl.startsWith("Im")?resourceUrl:'$'+resourceUrl}\n`);
+            writable.write(`Parent: ${resourceUrl.startsWith("Eu")?'$'+resourceUrl:resourceUrl}\n`);
             writable.write(`Id: ${actor}-${resourceName}\n`);
             writable.write(`Title: "${actor} obligations for ${resourceName}"\n`);
             writable.write(`Description: "${actor} obligations for ${resourceName}"\n`);


### PR DESCRIPTION
I’ve completed the first part of FHIR-51127 for the profiles in the _input/fsh/profiles folder_. 

Profile name aligned with the conventions used in the other guides.
“_Name : $Resource[$additionalInfo]Eu$Igkey for example BundleEuImaging; CompositionEuImaging;…
(upper camel notation)_"