### PR TITLE
Add GitHub workflow for auto-deploying to separate R4/R5 repositories

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,79 @@
+# Repository Deployment Setup
+
+This document explains how to configure the automatic deployment workflow that syncs the content of `igs/imaging-r4` and `igs/imaging-r5` folders to separate repositories.
+
+## Required Setup
+
+### 1. GitHub Secrets
+
+You need to create the following secret in your repository settings:
+
+#### `DEPLOY_TOKEN`
+- **Type**: Repository Secret
+- **Description**: A GitHub Personal Access Token with repository permissions
+- **How to create**:
+  1. Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
+  2. Generate a new token with the following scopes:
+     - `repo` (Full control of private repositories)
+     - `workflow` (Update GitHub Action workflows)
+  3. Copy the token and add it as a secret named `DEPLOY_TOKEN`
+
+### 2. Repository Variables (Optional)
+
+You can optionally configure the following variables to specify custom repository URLs:
+
+#### `R4_REPO_URL`
+- **Type**: Repository Variable
+- **Default**: `oijauregui/ehdsimaging-r4`
+- **Description**: The target repository for R4 content in format `owner/repo-name`
+
+#### `R5_REPO_URL`
+- **Type**: Repository Variable
+- **Default**: `oijauregui/ehdsimaging-r5`
+- **Description**: The target repository for R5 content in format `owner/repo-name`
+
+### 3. Target Repository Setup
+
+Make sure the target repositories (`ehdsimaging-r4` and `ehdsimaging-r5`) exist and the token has write access to them.
+
+## How It Works
+
+The workflow (`deploy-to-repos.yml`) triggers on any push to any branch and:
+
+1. **Preprocessing**: Runs `_preprocessMultiVersion.sh` to prepare the files
+2. **R4 Deployment**:
+   - Clones the target R4 repository
+   - Creates or switches to the same branch name as the source
+   - Syncs the content from `igs/imaging-r4/` to the root of the target repository
+   - Commits and pushes changes if any exist
+3. **R5 Deployment**:
+   - Clones the target R5 repository
+   - Creates or switches to the same branch name as the source
+   - Syncs the content from `igs/imaging-r5/` to the root of the target repository
+   - Commits and pushes changes if any exist
+
+## Branch Handling
+
+- The workflow preserves branch names across repositories
+- If a branch doesn't exist in the target repository, it creates a new one
+- If a branch exists, it updates the existing branch
+
+## Security Notes
+
+- The `DEPLOY_TOKEN` should be kept secure and rotated regularly
+- Consider using fine-grained personal access tokens for better security
+- The token should have minimal required permissions (repository access only)
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Permission Denied**: Ensure the `DEPLOY_TOKEN` has write access to target repositories
+2. **Repository Not Found**: Check that the repository URLs are correct and accessible
+3. **Branch Creation Fails**: Ensure the token has permission to create branches
+
+### Viewing Workflow Logs
+
+1. Go to the Actions tab in your GitHub repository
+2. Select the "Deploy to Separate Repositories" workflow
+3. Click on a specific run to view detailed logs for each step

--- a/.github/workflows/deploy-to-repos.yml
+++ b/.github/workflows/deploy-to-repos.yml
@@ -1,4 +1,4 @@
-name: Deploy to Separate Repositories
+name: Validate and Deploy to Separate Repositories
 
 on:
   push:
@@ -6,8 +6,73 @@ on:
   workflow_dispatch:  # Allow manual triggering
 
 jobs:
+  # Validation jobs run first
+  validate-r4:
+    runs-on: ubuntu-latest
+    name: Validate R4 IG
+    
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Jekyll
+        run: sudo gem install jekyll
+
+      - name: Install Sushi
+        run: sudo npm install -g fsh-sushi
+
+      - name: Preprocess
+        run: |
+          chmod u+x *.sh
+          ./_preprocessMultiVersion.sh
+
+      - name: Update IG publisher
+        working-directory: ./igs/imaging-r4
+        run: |
+          pwd
+          chmod +x ./_updatePublisher.sh
+          ./_updatePublisher.sh -y
+      
+      - name: Validate R4 IG
+        working-directory: ./igs/imaging-r4
+        run: |
+          pwd
+          ./_genonce.sh
+
+  validate-r5:
+    runs-on: ubuntu-latest
+    name: Validate R5 IG
+    
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Jekyll
+        run: sudo gem install jekyll
+
+      - name: Install Sushi
+        run: sudo npm install -g fsh-sushi
+
+      - name: Preprocess
+        run: |
+          chmod u+x *.sh
+          ./_preprocessMultiVersion.sh
+
+      - name: Update IG publisher
+        working-directory: ./igs/imaging-r5
+        run: |
+          pwd
+          chmod +x ./_updatePublisher.sh
+          ./_updatePublisher.sh -y
+      
+      - name: Validate R5 IG
+        working-directory: ./igs/imaging-r5
+        run: |
+          pwd
+          ./_genonce.sh
+
+  # Deployment jobs only run if validation passes
   deploy-r4:
     runs-on: ubuntu-latest
+    needs: [validate-r4, validate-r5]  # Wait for both validations to pass
     if: github.event_name == 'push'
     
     steps:
@@ -84,6 +149,7 @@ jobs:
 
   deploy-r5:
     runs-on: ubuntu-latest
+    needs: [validate-r4, validate-r5]  # Wait for both validations to pass
     if: github.event_name == 'push'
     
     steps:

--- a/.github/workflows/deploy-to-repos.yml
+++ b/.github/workflows/deploy-to-repos.yml
@@ -1,0 +1,159 @@
+name: Deploy to Separate Repositories
+
+on:
+  push:
+    branches: ['**']  # Trigger on any branch push
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  deploy-r4:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch full history for proper branch handling
+          token: ${{ secrets.DEPLOY_TOKEN }}
+
+      - name: Setup Git configuration
+        run: |
+          git config --global user.name "GitHub Actions Bot"
+          git config --global user.email "actions@github.com"
+
+      - name: Preprocess files
+        run: |
+          chmod u+x *.sh
+          ./_preprocessMultiVersion.sh
+
+      - name: Clone R4 target repository
+        env:
+          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+          R4_REPO_URL: ${{ vars.R4_REPO_URL || 'oijauregui/ehdsimaging-r4' }}
+        run: |
+          git clone https://$DEPLOY_TOKEN@github.com/$R4_REPO_URL.git r4-repo
+
+      - name: Prepare R4 repository branch
+        working-directory: ./r4-repo
+        run: |
+          # Get current branch name
+          BRANCH_NAME="${{ github.ref_name }}"
+          echo "Working with branch: $BRANCH_NAME"
+          
+          # Check if branch exists remotely
+          if git ls-remote --heads origin $BRANCH_NAME | grep -q $BRANCH_NAME; then
+            echo "Branch $BRANCH_NAME exists remotely, checking out"
+            git checkout $BRANCH_NAME
+          else
+            echo "Branch $BRANCH_NAME doesn't exist, creating new branch"
+            git checkout -b $BRANCH_NAME
+          fi
+
+      - name: Sync R4 content
+        run: |
+          # Remove all content from target repo except .git
+          find ./r4-repo -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+
+          # Copy imaging-r4 content to root of target repository
+          cp -r ./igs/imaging-r4/* ./r4-repo/
+          
+          # Ensure hidden files are copied too (excluding .git)
+          find ./igs/imaging-r4 -name ".*" -not -name ".git" -not -name "." -not -name ".." -exec cp -r {} ./r4-repo/ \; 2>/dev/null || true
+
+      - name: Commit and push R4 changes
+        working-directory: ./r4-repo
+        run: |
+          # Create a build trigger file to ensure there's always a commit for auto-ig-builder
+          echo "Build triggered at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" > .build-trigger
+          echo "Source commit: ${{ github.sha }}" >> .build-trigger
+          echo "Source branch: ${{ github.ref_name }}" >> .build-trigger
+          
+          git add -A
+          
+          # Always commit to ensure auto-ig-builder triggers
+          if git diff --staged --quiet; then
+            echo "No content changes, but creating trigger commit for auto-ig-builder"
+            git commit -m "Trigger auto-ig-builder - no content changes - source: ${{ github.sha }}"
+          else
+            git commit -m "Auto-sync from imaging repository - commit ${{ github.sha }}"
+          fi
+          
+          git push origin ${{ github.ref_name }}
+          echo "R4 repository updated successfully - auto-ig-builder should trigger"
+
+  deploy-r5:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch full history for proper branch handling
+          token: ${{ secrets.DEPLOY_TOKEN }}
+
+      - name: Setup Git configuration
+        run: |
+          git config --global user.name "GitHub Actions Bot"
+          git config --global user.email "actions@github.com"
+
+      - name: Preprocess files
+        run: |
+          chmod u+x *.sh
+          ./_preprocessMultiVersion.sh
+
+      - name: Clone R5 target repository
+        env:
+          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+          R5_REPO_URL: ${{ vars.R5_REPO_URL || 'oijauregui/ehdsimaging-r5' }}
+        run: |
+          git clone https://$DEPLOY_TOKEN@github.com/$R5_REPO_URL.git r5-repo
+
+      - name: Prepare R5 repository branch
+        working-directory: ./r5-repo
+        run: |
+          # Get current branch name
+          BRANCH_NAME="${{ github.ref_name }}"
+          echo "Working with branch: $BRANCH_NAME"
+          
+          # Check if branch exists remotely
+          if git ls-remote --heads origin $BRANCH_NAME | grep -q $BRANCH_NAME; then
+            echo "Branch $BRANCH_NAME exists remotely, checking out"
+            git checkout $BRANCH_NAME
+          else
+            echo "Branch $BRANCH_NAME doesn't exist, creating new branch"
+            git checkout -b $BRANCH_NAME
+          fi
+
+      - name: Sync R5 content
+        run: |
+          # Remove all content from target repo except .git
+          find ./r5-repo -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+
+          # Copy imaging-r5 content to root of target repository
+          cp -r ./igs/imaging-r5/* ./r5-repo/
+          
+          # Ensure hidden files are copied too (excluding .git)
+          find ./igs/imaging-r5 -name ".*" -not -name ".git" -not -name "." -not -name ".." -exec cp -r {} ./r5-repo/ \; 2>/dev/null || true
+
+      - name: Commit and push R5 changes
+        working-directory: ./r5-repo
+        run: |
+          # Create a build trigger file to ensure there's always a commit for auto-ig-builder
+          echo "Build triggered at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" > .build-trigger
+          echo "Source commit: ${{ github.sha }}" >> .build-trigger
+          echo "Source branch: ${{ github.ref_name }}" >> .build-trigger
+          
+          git add -A
+          
+          # Always commit to ensure auto-ig-builder triggers
+          if git diff --staged --quiet; then
+            echo "No content changes, but creating trigger commit for auto-ig-builder"
+            git commit -m "Trigger auto-ig-builder - no content changes - source: ${{ github.sha }}"
+          else
+            git commit -m "Auto-sync from imaging repository - commit ${{ github.sha }}"
+          fi
+          
+          git push origin ${{ github.ref_name }}
+          echo "R5 repository updated successfully - auto-ig-builder should trigger"


### PR DESCRIPTION
This workflow automatically syncs content from igs/imaging-r4 and igs/imaging-r5 to separate child repositories whenever changes are pushed.

Features:
- Runs ./_preprocessMultiVersion.sh script before deployment
- Syncs to configurable target repositories ( xxx/ehdsimaging-r4 and ehdsimaging-r5)
- Maintains branch names across repositories
- Includes build trigger files with timestamps for reliable detection

Setup required:
- DEPLOY_TOKEN secret with repo permissions (steps in README.md)
- Target repositories must exist
- Optional: R4_REPO_URL and R5_REPO_URL variables for custom targets