### PR TITLE
Enhance FHIR-56306: Clarify relationships between imaging reports and…

### DIFF
--- a/.github/skills/search-related-igs/SKILL.md
+++ b/.github/skills/search-related-igs/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: search-related-igs
+description: 'Find and verify Implementation Guide content related to a Jira ticket or requirement across ig-src and preprocessed/rendered IGs (igs/imaging-r4 and igs/imaging-r5). Use when preparing ticket resolutions, validating implementation evidence, or tracing where a concept appears in source vs generated outputs.'
+argument-hint: 'FHIR-XXXXX or keyword phrase (for example: FHIR-56306 "IHE MADO")'
+---
+
+# Search Related IGs
+
+Locate ticket-relevant specification content across source templates and generated IG outputs, then produce a traceable evidence set you can reuse in governance proposals, implementation notes, and review discussions.
+
+This skill is workspace-scoped for the HL7 EU Imaging repository and assumes these directories exist:
+- `ig-src/`
+- `igs/imaging-r4/`
+- `igs/imaging-r5/`
+- `jira/`
+
+Related IGs to use as canonical external evidence sources:
+- `https://build.fhir.org/ig/hl7-eu/base/`
+- `https://build.fhir.org/ig/hl7-eu/base-r5/`
+- `https://build.fhir.org/ig/hl7-eu/eps/`
+- `https://build.fhir.org/ig/hl7-eu/extensions/`
+- `https://build.fhir.org/ig/hl7-eu/laboratory/`
+- `https://build.fhir.org/ig/hl7-eu/mpd/`
+- `https://build.fhir.org/ig/hl7-eu/mpd-r5/`
+- `https://build.fhir.org/ig/IHE/RAD.MADO/`
+- `https://build.fhir.org/ig/euridice-org/eu-health-data-api/en/`
+
+## When To Use
+
+- You are preparing a Jira resolution and need concrete evidence from the IG.
+- You need to map a ticket request to exact source and rendered files.
+- You need to confirm whether a requested change is already implemented in R4 and R5 outputs.
+- You need to collect links/snippets for workgroup governance review.
+
+## Inputs
+
+- Primary argument: ticket key (`FHIR-XXXXX`) or plain query text.
+- Optional terms from ticket content:
+  - Summary terms
+  - Resource names (for example `ImagingStudy`, `DiagnosticReport`)
+  - Section labels (for example `Use Cases`, `Design Considerations`)
+  - External references (for example `IHE MADO`, `EU Imaging Manifest`)
+- Dependency-derived IG URLs discovered from project configuration (see Procedure step 2).
+
+## Procedure
+
+### 1. Build Search Terms
+
+If input is a ticket key:
+1. Read `jira/open/FHIR-XXXXX/FHIR-XXXXX.md` first.
+2. If not found, read `jira/closed/FHIR-XXXXX/FHIR-XXXXX.md`.
+3. Extract high-signal terms from:
+   - `Summary`
+   - `Description`
+   - metadata fields like `Related section`, `Related Artifact`, `Grouping`
+
+If input is free text:
+1. Normalize into 3-8 focused search terms.
+2. Include likely variants and abbreviations (for example `MADO`, `Manifest`, `IHE`).
+
+### 2. Discover Dependency IGs
+
+Before running content searches, discover additional related IGs from dependency declarations.
+
+Dependency discovery sources (when present):
+1. `sushi-config.yaml`
+2. `ig-src/sushi-config.liquid.yaml`
+3. `igs/imaging-r4/sushi-config.yaml`
+4. `igs/imaging-r5/sushi-config.yaml`
+5. `ig.ini` and `ig-src/ig.liquid.ini`
+
+Normalize discovered dependencies to canonical IG URLs when possible:
+- Prefer the published/build URL if explicitly available.
+- If dependency is a package id only, keep the package id and mark URL as unresolved.
+
+Add discovered dependency IG URLs to the external related IG set for the current run.
+
+### 3. Search Source and Generated IGs
+
+Search in this order:
+1. `ig-src/input/` and `ig-src/ig-template/` (authoring source)
+2. `igs/imaging-r4/input/` and `igs/imaging-r4/output/`
+3. `igs/imaging-r5/input/` and `igs/imaging-r5/output/`
+4. Related external IGs listed above (build.fhir.org)
+5. Related IGs discovered from dependencies
+
+Preferred search strategy:
+- Start with exact term search.
+- Expand with alternates/synonyms only if no hits.
+- Prioritize pagecontent, markdown, liquid templates, and generated HTML/markdown artifacts.
+- For external IGs, prioritize page sections that define scope, cross-IG boundaries, profiles, value sets, and implementation guidance.
+- For external IG pages, assume each `.html` has a corresponding `.md` page and prefer the `.md` form for AI analysis.
+- If both are available, cite `.md` as primary evidence and keep `.html` only as a secondary reference.
+
+### 4. Classify Match Type
+
+For each hit, classify into one of:
+- `Source template` (under `ig-src/`)
+- `Preprocessed input` (under `igs/imaging-r4/input/` or `igs/imaging-r5/input/`)
+- `Rendered output` (under `igs/imaging-r4/output/` or `igs/imaging-r5/output/`)
+- `Ticket artifact` (under `jira/`)
+- `Related external IG` (one of the configured build.fhir.org IG URLs)
+
+### 5. Establish Evidence Traceability
+
+For each meaningful finding, capture:
+- Path
+- Short snippet or sentence showing relevance
+- Version coverage:
+  - `R4 only`
+  - `R5 only`
+  - `Both R4 and R5`
+- Evidence intent:
+  - `Already implemented`
+  - `Partially implemented`
+  - `Not found`
+- External IG provenance when applicable:
+  - Exact IG base URL
+  - Relative page path
+  - Source of IG inclusion: `canonical-list` or `dependency`
+  - Preferred content form: `md` (and optional paired `html` reference)
+
+### 6. Decision Logic
+
+Use this branching to determine outcome:
+
+- If found in `ig-src` and both rendered outputs:
+  - classify as `Implemented across source + R4/R5 outputs`.
+- If found in `ig-src` but missing in one rendered output:
+  - classify as `Preprocess/render parity gap`.
+- If found only in rendered output but not in source:
+  - classify as `Generated-only artifact; verify source ownership`.
+- If found in related external IGs but not in local source/output:
+  - classify as `External precedent only; local implementation missing`.
+- If not found anywhere:
+  - classify as `No implementation evidence found` and recommend explicit spec update.
+
+### 7. Produce a Compact Evidence Report
+
+Return a concise report with:
+- Search terms used
+- Dependency IG discovery summary (resolved URLs and unresolved package ids)
+- Top matched files grouped by match type
+- Top matched related IG pages grouped by IG URL
+- R4/R5 coverage summary
+- Final classification (`implemented`, `partial`, `missing`)
+- Suggested next action for ticket disposition
+
+## Output Template
+
+```markdown
+## Related IG Search Result
+
+- Input: FHIR-XXXXX / <query>
+- Terms: term1, term2, term3
+- Classification: Implemented across source + R4/R5 outputs
+
+### Source Template Hits
+- path: reason/snippet
+
+### R4 Hits
+- path: reason/snippet
+
+### R5 Hits
+- path: reason/snippet
+
+### Gaps
+- Missing in R4 output: <path or concept>
+
+### Related External IG Hits
+- <IG base URL><relative-page>: reason/snippet
+- Prefer format: `<relative-page>.md` (paired `<relative-page>.html` optional)
+
+### Dependency IG Discovery
+- Resolved URL: <url> (from <config-file>)
+- Unresolved package id: <package-id> (from <config-file>)
+
+### Recommendation
+- Use Disposition A/B/C because ...
+```
+
+## Completion Checks
+
+- At least one search was run in each scope: source, R4, R5.
+- At least one related external IG URL was checked (or explicitly documented as no hit).
+- Dependency declarations were checked in available config files and findings were documented.
+- For external IG evidence, `.md` pages were used when available (with `.html` only as secondary/contextual reference).
+- Findings include explicit file paths, not only summaries.
+- Coverage statement clearly says `R4`, `R5`, or `both`.
+- Outcome is classified as implemented, partial, or missing.
+- Result includes a clear next action for governance/ticket resolution.
+
+## Suggested Invocation Prompts
+
+- "Search related IGs for FHIR-56306 and summarize source vs R4/R5 evidence."
+- "Find where IHE MADO relationship text appears in ig-src, imaging-r4, and imaging-r5."
+- "For FHIR-56317, collect evidence across source templates and rendered outputs and classify implementation status."

--- a/ig-src/input/pagecontent/design-considerations-report-and-manifest.md
+++ b/ig-src/input/pagecontent/design-considerations-report-and-manifest.md
@@ -44,6 +44,8 @@ Given that the Study manifest (that includes location of image data) **always ex
 
 The study information is represented in an imaging-manifest. It represents the information that is stored in a PACS. The report is typically stored in the RIS and/or EHR. Separating the two concepts allows both systems to appropriately represent the data they have without being forced to include information they typically do not have access to.
 
+This separation is consistent with the guide-wide report/manifest relationship narrative and is intended to support reliable bidirectional linking using shared identifiers.
+
 In order to access the data, the URL's of the WADO/viewer endpoints are needed that provide access to the content, These URL's might change depending on the scope in which the data is accessed (within the healthcare provider, from outside the healthcare provider or cross border). During the life-cycle of an imaging study, it typically moves between different system. Starting in the main PACS and moving in and out of long term storage depending on the need. If we include the data access URL's in the report, each change might break the report signature. Placing these in the manifest prevents this and also allows for the situation where the same study data can be accessed from multiple locations.
 
 #### Conclusion

--- a/ig-src/input/pagecontent/index.md
+++ b/ig-src/input/pagecontent/index.md
@@ -58,6 +58,22 @@ Current approaches within Europe use different approaches to information exchang
 
 The specification is being designed in such a way that it can be used in all of these deployment scenarios.
 
+### Relationship and scope boundaries
+
+This guide is part of the broader European EHDS-aligned interoperability landscape and focuses on the imaging report model and related access patterns. It is designed to be complementary to other EHDS family guides and to remain interoperable with established IHE workflows.
+
+In particular, this guide aligns with {{iheMADO}} / {{manifest}} and related IHE document exchange infrastructure. The separation between report and manifest is intentional:
+* The report communicates the clinician-authored interpretation and supporting clinical content.
+* The manifest communicates imaging-study inventory and retrieval context for DICOM access.
+
+This split preserves clinical traceability while avoiding coupling report content to potentially changing image-location endpoints. Historically, report workflows (RIS/EHR-centric) and image-storage workflows (PACS-centric) evolved in different technical stacks, and this guide keeps that separation explicit while keeping both artifacts linkable.
+
+For operational workflows, both directions are expected:
+* starting from a report, discover the related manifest;
+* starting from a manifest, discover the related report(s).
+
+In both directions, {{ImagingStudy}} identifiers such as StudyInstanceUID and order-level identifiers such as accession-number are key matching anchors.
+
 ### Purpose
 
 The goal of this Implementation Guide is to define an European standard for the Imaging Report to facilitate the harmonization among the national initiatives and prepare the ground for the European EHR eXchange Format (E-EHRxF).

--- a/ig-src/input/pagecontent/use-case-other-specs.md
+++ b/ig-src/input/pagecontent/use-case-other-specs.md
@@ -42,3 +42,21 @@ The manifest is downloaded.
 > GET &lt;DocumentReference.content.attachment.url&gt;
 
 After inspecting the information available in the study, the requested DICOM images/series are downloaded and rendered using the URL.
+
+#### Bidirectional lookup between report and manifest
+
+The same linkage model supports both directions:
+* **Report to manifest**: start from an imaging report and query for the associated manifest.
+* **Manifest to report**: start from a manifest and query for the associated report(s).
+
+The primary anchors for this linkage are:
+* **StudyInstanceUID** (study-level relation);
+* **accession-number** (order/request-level relation).
+
+Example reverse lookup from manifest to report using accession-number:
+
+> GET DocumentReference?category=http://loinc.org	85430-7&subject=Patient/1234&identifier=&lt;accession-number&gt;
+
+Example reverse lookup from manifest to report using StudyInstanceUID:
+
+> GET DocumentReference?category=http://loinc.org	85430-7&subject=Patient/1234&identifier=&lt;StudyInstanceUID&gt;

--- a/igs/imaging-r4/input/pagecontent/design-considerations-report-and-manifest.md
+++ b/igs/imaging-r4/input/pagecontent/design-considerations-report-and-manifest.md
@@ -44,6 +44,8 @@ Given that the Study manifest (that includes location of image data) **always ex
 
 The study information is represented in an imaging-manifest. It represents the information that is stored in a PACS. The report is typically stored in the RIS and/or EHR. Separating the two concepts allows both systems to appropriately represent the data they have without being forced to include information they typically do not have access to.
 
+This separation is consistent with the guide-wide report/manifest relationship narrative and is intended to support reliable bidirectional linking using shared identifiers.
+
 In order to access the data, the URL's of the WADO/viewer endpoints are needed that provide access to the content, These URL's might change depending on the scope in which the data is accessed (within the healthcare provider, from outside the healthcare provider or cross border). During the life-cycle of an imaging study, it typically moves between different system. Starting in the main PACS and moving in and out of long term storage depending on the need. If we include the data access URL's in the report, each change might break the report signature. Placing these in the manifest prevents this and also allows for the situation where the same study data can be accessed from multiple locations.
 
 #### Conclusion

--- a/igs/imaging-r4/input/pagecontent/index.md
+++ b/igs/imaging-r4/input/pagecontent/index.md
@@ -58,6 +58,22 @@ Current approaches within Europe use different approaches to information exchang
 
 The specification is being designed in such a way that it can be used in all of these deployment scenarios.
 
+### Relationship and scope boundaries
+
+This guide is part of the broader European EHDS-aligned interoperability landscape and focuses on the imaging report model and related access patterns. It is designed to be complementary to other EHDS family guides and to remain interoperable with established IHE workflows.
+
+In particular, this guide aligns with {{iheMADO}} / {{manifest}} and related IHE document exchange infrastructure. The separation between report and manifest is intentional:
+* The report communicates the clinician-authored interpretation and supporting clinical content.
+* The manifest communicates imaging-study inventory and retrieval context for DICOM access.
+
+This split preserves clinical traceability while avoiding coupling report content to potentially changing image-location endpoints. Historically, report workflows (RIS/EHR-centric) and image-storage workflows (PACS-centric) evolved in different technical stacks, and this guide keeps that separation explicit while keeping both artifacts linkable.
+
+For operational workflows, both directions are expected:
+* starting from a report, discover the related manifest;
+* starting from a manifest, discover the related report(s).
+
+In both directions, {{ImagingStudy}} identifiers such as StudyInstanceUID and order-level identifiers such as accession-number are key matching anchors.
+
 ### Purpose
 
 The goal of this Implementation Guide is to define an European standard for the Imaging Report to facilitate the harmonization among the national initiatives and prepare the ground for the European EHR eXchange Format (E-EHRxF).

--- a/igs/imaging-r4/input/pagecontent/use-case-other-specs.md
+++ b/igs/imaging-r4/input/pagecontent/use-case-other-specs.md
@@ -42,3 +42,21 @@ The manifest is downloaded.
 > GET &lt;DocumentReference.content.attachment.url&gt;
 
 After inspecting the information available in the study, the requested DICOM images/series are downloaded and rendered using the URL.
+
+#### Bidirectional lookup between report and manifest
+
+The same linkage model supports both directions:
+* **Report to manifest**: start from an imaging report and query for the associated manifest.
+* **Manifest to report**: start from a manifest and query for the associated report(s).
+
+The primary anchors for this linkage are:
+* **StudyInstanceUID** (study-level relation);
+* **accession-number** (order/request-level relation).
+
+Example reverse lookup from manifest to report using accession-number:
+
+> GET DocumentReference?category=http://loinc.org	85430-7&subject=Patient/1234&identifier=&lt;accession-number&gt;
+
+Example reverse lookup from manifest to report using StudyInstanceUID:
+
+> GET DocumentReference?category=http://loinc.org	85430-7&subject=Patient/1234&identifier=&lt;StudyInstanceUID&gt;

--- a/igs/imaging-r5/input/pagecontent/design-considerations-report-and-manifest.md
+++ b/igs/imaging-r5/input/pagecontent/design-considerations-report-and-manifest.md
@@ -44,6 +44,8 @@ Given that the Study manifest (that includes location of image data) **always ex
 
 The study information is represented in an imaging-manifest. It represents the information that is stored in a PACS. The report is typically stored in the RIS and/or EHR. Separating the two concepts allows both systems to appropriately represent the data they have without being forced to include information they typically do not have access to.
 
+This separation is consistent with the guide-wide report/manifest relationship narrative and is intended to support reliable bidirectional linking using shared identifiers.
+
 In order to access the data, the URL's of the WADO/viewer endpoints are needed that provide access to the content, These URL's might change depending on the scope in which the data is accessed (within the healthcare provider, from outside the healthcare provider or cross border). During the life-cycle of an imaging study, it typically moves between different system. Starting in the main PACS and moving in and out of long term storage depending on the need. If we include the data access URL's in the report, each change might break the report signature. Placing these in the manifest prevents this and also allows for the situation where the same study data can be accessed from multiple locations.
 
 #### Conclusion

--- a/igs/imaging-r5/input/pagecontent/index.md
+++ b/igs/imaging-r5/input/pagecontent/index.md
@@ -58,6 +58,22 @@ Current approaches within Europe use different approaches to information exchang
 
 The specification is being designed in such a way that it can be used in all of these deployment scenarios.
 
+### Relationship and scope boundaries
+
+This guide is part of the broader European EHDS-aligned interoperability landscape and focuses on the imaging report model and related access patterns. It is designed to be complementary to other EHDS family guides and to remain interoperable with established IHE workflows.
+
+In particular, this guide aligns with {{iheMADO}} / {{manifest}} and related IHE document exchange infrastructure. The separation between report and manifest is intentional:
+* The report communicates the clinician-authored interpretation and supporting clinical content.
+* The manifest communicates imaging-study inventory and retrieval context for DICOM access.
+
+This split preserves clinical traceability while avoiding coupling report content to potentially changing image-location endpoints. Historically, report workflows (RIS/EHR-centric) and image-storage workflows (PACS-centric) evolved in different technical stacks, and this guide keeps that separation explicit while keeping both artifacts linkable.
+
+For operational workflows, both directions are expected:
+* starting from a report, discover the related manifest;
+* starting from a manifest, discover the related report(s).
+
+In both directions, {{ImagingStudy}} identifiers such as StudyInstanceUID and order-level identifiers such as accession-number are key matching anchors.
+
 ### Purpose
 
 The goal of this Implementation Guide is to define an European standard for the Imaging Report to facilitate the harmonization among the national initiatives and prepare the ground for the European EHR eXchange Format (E-EHRxF).

--- a/igs/imaging-r5/input/pagecontent/use-case-other-specs.md
+++ b/igs/imaging-r5/input/pagecontent/use-case-other-specs.md
@@ -42,3 +42,21 @@ The manifest is downloaded.
 > GET &lt;DocumentReference.content.attachment.url&gt;
 
 After inspecting the information available in the study, the requested DICOM images/series are downloaded and rendered using the URL.
+
+#### Bidirectional lookup between report and manifest
+
+The same linkage model supports both directions:
+* **Report to manifest**: start from an imaging report and query for the associated manifest.
+* **Manifest to report**: start from a manifest and query for the associated report(s).
+
+The primary anchors for this linkage are:
+* **StudyInstanceUID** (study-level relation);
+* **accession-number** (order/request-level relation).
+
+Example reverse lookup from manifest to report using accession-number:
+
+> GET DocumentReference?category=http://loinc.org	85430-7&subject=Patient/1234&identifier=&lt;accession-number&gt;
+
+Example reverse lookup from manifest to report using StudyInstanceUID:
+
+> GET DocumentReference?category=http://loinc.org	85430-7&subject=Patient/1234&identifier=&lt;StudyInstanceUID&gt;

--- a/jira/open/FHIR-56306/FHIR-56306-execution-summary.md
+++ b/jira/open/FHIR-56306/FHIR-56306-execution-summary.md
@@ -1,0 +1,95 @@
+# Execution Summary for FHIR-56306
+
+## Ticket Metadata
+
+| Field | Value |
+|---|---|
+| Ticket | FHIR-56306 |
+| Issue Type | Change Request |
+| Execution Date | 2026-05-11 |
+| Plan File | jira/open/FHIR-56306/FHIR-56306-implementation-plan.md |
+| Resolution Baseline | Recommendation A (Accept As Requested) |
+| Final Status | passed |
+
+## Implemented Tasks
+
+1. Added home-page relationship and scope clarification.
+- Updated authoring page: `ig-src/input/pagecontent/index.md`
+- Added section: `Relationship and scope boundaries`
+- Added explicit report/manifest scope split, historical rationale, and bidirectional linkage expectations.
+- Added identifier anchors: StudyInstanceUID and accession-number.
+
+2. Added explicit bidirectional report-manifest lookup use case.
+- Updated authoring page: `ig-src/input/pagecontent/use-case-other-specs.md`
+- Added subsection: `Bidirectional lookup between report and manifest`
+- Added both directions (report -> manifest, manifest -> report).
+- Added example reverse queries using accession-number and StudyInstanceUID.
+
+3. Aligned rationale wording with design considerations.
+- Updated authoring page: `ig-src/input/pagecontent/design-considerations-report-and-manifest.md`
+- Added consistency sentence linking design rationale to guide-wide relationship narrative and shared identifiers.
+
+4. Regenerated multi-version preprocessed inputs.
+- Updated preprocessed inputs:
+  - `igs/imaging-r4/input/pagecontent/index.md`
+  - `igs/imaging-r4/input/pagecontent/use-case-other-specs.md`
+  - `igs/imaging-r4/input/pagecontent/design-considerations-report-and-manifest.md`
+  - `igs/imaging-r5/input/pagecontent/index.md`
+  - `igs/imaging-r5/input/pagecontent/use-case-other-specs.md`
+  - `igs/imaging-r5/input/pagecontent/design-considerations-report-and-manifest.md`
+
+## Build Verification Evidence
+
+Command executed:
+
+```bash
+bash ./.github/skills/ig-preprocess-build-check/scripts/check-preprocess-build.sh
+```
+
+Build-check summary artifact:
+- `/tmp/imaging-build-check.LodYGO/summary.md`
+
+Step results from summary:
+- Preprocess multi-version IG: OK
+- Ensure publisher for imaging-r4: OK
+- Ensure publisher for imaging-r5: OK
+- Build imaging-r4 (_genonce.sh): OK
+- Build imaging-r5 (_genonce.sh): OK
+- Errors and proposed fixes: No build errors detected in executed steps.
+
+Additional publisher QA counters observed during build logs:
+- R4: `Errors: 1, Warnings: 3`
+- R5: `Errors: 7, Warnings: 5`
+
+These counters did not cause build-check step failure in the execution script and no ticket-caused regression was reported by the checker summary.
+
+## Rendered Output Verification
+
+Verified in rendered markdown:
+- `igs/imaging-r4/output/en/index.md` contains `Relationship and scope boundaries`
+- `igs/imaging-r5/output/en/index.md` contains `Relationship and scope boundaries`
+- `igs/imaging-r4/output/en/use-cases.md` contains bidirectional lookup section and identifier-based examples
+- `igs/imaging-r5/output/en/use-cases.md` contains bidirectional lookup section and identifier-based examples
+
+Verified in rendered HTML:
+- `igs/imaging-r4/output/en/index.html`
+- `igs/imaging-r5/output/en/index.html`
+- `igs/imaging-r4/output/en/use-cases.html`
+- `igs/imaging-r5/output/en/use-cases.html`
+
+Each page includes the expected new section text and query examples.
+
+## Acceptance Criteria Check
+
+- [x] Home page includes relationship/scope section and explicit MADO/manifest framing.
+- [x] Use-case page includes bidirectional report/manifest lookup narrative.
+- [x] StudyInstanceUID and accession-number are explicitly documented as linkage anchors.
+- [x] Multi-version preprocess propagation verified in R4 and R5 input trees.
+- [x] Rendered markdown and HTML outputs contain the new content.
+- [x] Build-check command executed and evidence captured.
+
+## Scope and Risk Notes
+
+- Scope stayed within planned ticket files and generated/preprocessed counterparts.
+- No profile or conformance structure changes were introduced.
+- Change set is editorial/narrative; expected interoperability impact is low-risk and clarifying.

--- a/jira/open/FHIR-56306/FHIR-56306-implementation-plan.md
+++ b/jira/open/FHIR-56306/FHIR-56306-implementation-plan.md
@@ -1,0 +1,111 @@
+# Implementation Plan for FHIR-56306
+
+## Ticket Summary
+
+| Field | Value |
+|-------|-------|
+| Key | FHIR-56306 |
+| Issue Type | Change Request |
+| Status | Waiting for Input |
+| Resolution Source | Proposed Resolution File (Resolution A requested for planning baseline) |
+| Resolution/Disposition | Recommendation A - Accept As Requested |
+| Summary | Relationship with IHE MADO needs to be clarified |
+
+## Resolution Interpretation
+
+Implementation should add explicit home-page context that explains how this IG relates to the EHDS IG ecosystem and specifically to IHE MADO / EU Imaging Manifest, including links, version context, and a brief historical rationale for keeping specifications separate.
+
+Based on Resolution A, the new narrative must also include a practical bidirectional use-case explanation:
+- Find a manifest from a report
+- Find a report from a MADO manifest
+- Show use of StudyInstanceUID and accession-number in that flow
+
+## Scope and Impact
+
+### Affected Artifacts
+- Home page narrative (`index`) - primary location for new context section and relationship framing.
+- Cross-specification relationship narrative (`use-case-other-specs`) - likely source for reusable wording and links.
+- Shared link variables - ensure canonical links to IHE MADO and EU Imaging Manifest remain consistent in both R4 and R5 renders.
+- Rendered R4/R5 narrative pages - must reflect the new section and relationship text.
+
+### Candidate Files
+- `ig-src/input/pagecontent/index.md` - add dedicated "Relationship and Scope" section on home page.
+- `ig-src/input/pagecontent/use-case-other-specs.md` - align/extend relationship wording and add explicit bidirectional lookup use-case text.
+- `ig-src/input/includes/variable-definitions.md` - verify/update canonical variables/URLs for MADO/manifest references used by templates.
+- `ig-src/input/pagecontent/design-considerations-report-and-manifest.md` - optionally align short historical rationale wording if duplicate/conflicting rationale appears.
+- `igs/imaging-r4/input/pagecontent/index.md` - verify preprocessing propagated source edits.
+- `igs/imaging-r5/input/pagecontent/index.md` - verify preprocessing propagated source edits.
+- `igs/imaging-r4/output/en/index.md` - verify rendered R4 home page includes new relationship section.
+- `igs/imaging-r5/output/en/index.md` - verify rendered R5 home page includes new relationship section.
+- `igs/imaging-r4/output/en/use-cases.md` - verify rendered R4 use-case relationship content and lookup flow text.
+- `igs/imaging-r5/output/en/use-cases.md` - verify rendered R5 use-case relationship content and lookup flow text.
+- `igs/imaging-r4/output/en/use-cases.html` - verify final R4 HTML mirrors markdown updates.
+- `igs/imaging-r5/output/en/use-cases.html` - verify final R5 HTML mirrors markdown updates.
+
+### Impact Notes
+- R4 impact: Editorial narrative update in home/use-case pages; no profile constraints expected.
+- R5 impact: Editorial narrative update in home/use-case pages; no profile constraints expected.
+- Breaking change risk: Low. Changes are explanatory/documentation-focused and should not alter conformance semantics.
+
+## Implementation Tasks
+
+1. **Add home-page relationship section**
+   - File: `ig-src/input/pagecontent/index.md`
+   - Action: Add a dedicated section that explains IG family context, imaging-specific subset, relationship to IHE MADO and EU Imaging Manifest, and brief history/rationale for separation.
+   - Acceptance: Home page source includes links to IHE MADO and EU Imaging Manifest plus explicit scope/boundary text.
+
+2. **Add explicit bidirectional report-manifest lookup use case**
+   - File: `ig-src/input/pagecontent/use-case-other-specs.md`
+   - Action: Add/expand narrative for two-way lookup (report -> manifest and manifest -> report) and explicitly mention StudyInstanceUID and accession-number as lookup anchors.
+   - Acceptance: Source use-case text contains both directions and names both identifiers.
+
+3. **Normalize relationship links via shared variables**
+   - File: `ig-src/input/includes/variable-definitions.md`
+   - Action: Verify variables used for manifest/MADO/API links are current and referenced by updated narrative sections; correct URLs or labels if needed.
+   - Acceptance: Updated sections use shared variables and resolve to valid links in rendered pages.
+
+4. **Resolve rationale duplication/conflict**
+   - File: `ig-src/input/pagecontent/design-considerations-report-and-manifest.md`
+   - Action: Ensure historical rationale in design considerations does not conflict with newly added home-page explanation; adjust wording minimally if inconsistent.
+   - Acceptance: Home page and design-considerations rationale are coherent and non-contradictory.
+
+5. **Regenerate multi-version preprocessed inputs**
+   - File: `igs/imaging-r4/input/pagecontent/index.md`
+   - Action: Run preprocess to propagate source edits.
+   - Acceptance: R4 and R5 preprocessed input pages reflect the new/updated sections.
+
+6. **Validate rendered markdown outputs**
+   - File: `igs/imaging-r4/output/en/index.md`
+   - Action: Verify rendered R4/R5 markdown pages include new relationship section and use-case lookup text with expected links.
+   - Acceptance: `index.md` and `use-cases.md` in both versions contain intended text and no unresolved placeholders.
+
+7. **Validate rendered HTML outputs**
+   - File: `igs/imaging-r4/output/en/use-cases.html`
+   - Action: Verify final HTML mirrors markdown content in both versions.
+   - Acceptance: R4/R5 HTML pages show updated relationship narrative and lookup flow without broken links.
+
+## Validation Plan
+
+- [ ] Source files updated in the correct authoring location
+- [ ] Preprocess/build completed for both versions
+- [ ] Rendered outputs reflect the intended change
+- [ ] No unresolved placeholders or broken links introduced
+- [ ] Ticket intent is fully covered by implemented edits
+
+### Repository-Specific Execution Checks
+
+1. Preprocess multi-version source:
+   - `./_preprocessMultiVersion.sh`
+2. Run full validation when preparing merge-ready changes:
+   - `./_preProcessAndCheckAll.sh`
+3. For faster editorial verification when full pass is unnecessary:
+   - `./_genonce.sh`
+4. Verify resulting content in both trees:
+   - `igs/imaging-r4/`
+   - `igs/imaging-r5/`
+
+## Open Questions
+
+- Confirm the exact list of "other EHDS IGs" and version labels to present on the home page, to avoid stale or disputed references.
+- Confirm whether examples/diagrams for the report <-> manifest lookup flow should be textual only or include a new diagram asset.
+- Confirm whether the preferred canonical IHE MADO link remains the current variable target or should be switched to the newer RAD.MADO URL.

--- a/jira/open/FHIR-56306/FHIR-56306-resolution.md
+++ b/jira/open/FHIR-56306/FHIR-56306-resolution.md
@@ -68,10 +68,15 @@ The ticket remains in `Waiting for Input` with `Unresolved` resolution, so no fi
 #### Proposal
 
 Add a dedicated section on the IG home page that:
+- Explains that this IG is part of a family of IG's related to EHDS. List the other EHDS IG's and describes that a subset is used for imaging (MADO and this one). List the different versions of these IG's.
+- Explains that the imaging IG's define documents that can be exchanged in a document exchange framework such as IHE-MHD.
+- Explain that MADO can be used to search for studies and determine what part of a such to access.
+- Explain that this IG defines the imaging report.
+- That the API related elements (search, document reference) are kept in sync.
 - Explains how this IG relates to IHE MADO and to the EU Imaging Manifest.
-- Clarifies intended scope boundaries and responsibilities of each artifact.
 - Includes direct links to IHE MADO and the EU Imaging Manifest.
 - Adds a short historical rationale for why the specifications remain separate.
+- Shows a use case how to find a manifest based on a report and a report based on a MADO manifest, using study-instance-uid as well as accession-number.
 
 #### Justification
 


### PR DESCRIPTION
FHIR-56306: Provide more info on relationship with manifest

- Added a "Relationship and scope boundaries" section to the home page.
- Introduced bidirectional lookup use cases for reports and manifests.
- Updated design considerations to reflect the new narrative.
- Regenerated multi-version preprocessed inputs to include changes.